### PR TITLE
docs: rewrite README.md and ARCHITECTURE.md to reflect actual codebase

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,274 +2,378 @@
 
 ## Overview
 
-Embedder Service is an HTTP microservice that accepts text input and returns vector embeddings. It provides a simple, provider-agnostic REST API that abstracts over multiple embedding model backends (OpenAI, HuggingFace, local models). Downstream consumers — such as RAG pipelines, semantic search engines, and recommendation systems — can integrate with a single, stable API regardless of which embedding model is in use.
-
-The service is designed to be lightweight, horizontally scalable, and easy to operate in containerised environments.
+The Code Indexer Service is a Python/FastAPI HTTP service that turns codebases
+into searchable vector databases. It clones or receives source code, parses it
+into structured symbols (functions, classes, imports), builds relationship
+graphs, generates vector embeddings, and stores everything in Postgres/pgvector
+for semantic search.
 
 ```mermaid
 graph LR
-    Client[Client Application] -->|HTTP POST /v1/embed| API[API Layer]
-    API -->|Validate request| Validation[Request Validation]
-    Validation -->|Forward texts + config| Embedding[Embedding Engine]
-    Embedding -->|Route to provider| Provider[Model Provider]
-    Provider -->|Return vectors| Embedding
-    Embedding -->|Cache result| Cache[Cache Layer]
-    Embedding -->|Return response| API
-    API -->|JSON response| Client
-
-    subgraph Model Providers
-        OpenAI[OpenAI API]
-        HuggingFace[HuggingFace Inference]
-        Local[Local Model Runtime]
+    subgraph Clients
+        CLI[curl / SDK]
+        Web[Web UI]
     end
 
-    Provider --- OpenAI
-    Provider --- HuggingFace
-    Provider --- Local
+    CLI -->|HTTP| API[FastAPI<br/>main.py]
+    Web -->|HTTP| API
+
+    subgraph Indexing Pipeline
+        API -->|Queue job| Jobs[Job Tracker<br/>db.py]
+        Jobs -->|Background| Scan[File Scanner<br/>file_scanner.py]
+        Scan -->|Files| Lang[Language Router<br/>language_router.py]
+        Lang -->|Per file| Analyzers[Analyzers<br/>python, go, js, ...]
+        Analyzers -->|FileAnalysis| Chunker[Chunker<br/>chunker.py]
+        Analyzers -->|Analyses| Graphs[Graph Builder<br/>graph.py]
+        Graphs -->|Enrich| Chunker
+        Chunker -->|Chunks| Embedder[Embedder<br/>embedder.py]
+        Embedder -->|Vectors| Store[pgvector<br/>store/pgvector_store.py]
+    end
+
+    subgraph Query Path
+        API -->|POST /search/text| QEmbed[Embedder]
+        QEmbed -->|Query vector| Store
+        Store -->|Top-k results| API
+    end
+
+    subgraph Storage
+        PG[(Postgres<br/>+ pgvector)]
+    end
+
+    Store --> PG
+    Jobs --> PG
 ```
 
-## Component Breakdown
+## Core Components
 
-The service is composed of five core components:
+### 1. API Layer (`main.py`)
 
-### 1. API Layer
+The FastAPI application that exposes all HTTP endpoints. Built with:
 
-The HTTP server that receives client requests, validates input, and returns responses.
+- **FastAPI** with Pydantic v2 request/response models
+- **Background tasks** for long-running indexing jobs
+- **Bearer token auth** on management endpoints (upload, delete, job status)
+- **Webhook notifications** with optional HMAC-SHA256 signatures
 
-- **Framework:** Go standard library `net/http` (with a lightweight router such as `chi` or `gorilla/mux`)
-- **Responsibilities:**
-  - Route incoming requests to the appropriate handler
-  - Parse and validate request bodies (JSON schema validation)
-  - Serialise responses with consistent error formatting
-  - Expose health (`/healthz`) and readiness (`/readyz`) endpoints
-  - Handle CORS, request timeouts, and graceful shutdown
-  <!-- TODO: confirm whether OpenAPI spec generation is desired -->
+**Endpoints:**
 
-### 2. Embedding Engine
+| Endpoint | Purpose |
+|----------|---------|
+| `POST /github/index` | Queue a GitHub repo or local path for indexing |
+| `POST /embeddings/{ns}/{pid}` | Upload a zip and index it |
+| `POST /search/text` | Search with raw query text (auto-picks model) |
+| `POST /search` | Search with a pre-computed embedding vector |
+| `POST /embed` | Embed arbitrary text |
+| `GET /embeddings/{ns}/{pid}` | Read index metadata |
+| `DELETE /embeddings/{ns}/{pid}` | Delete a project's index |
+| `GET /jobs/{job_id}` | Poll indexing job status |
+| `GET /` | Serve the built-in API documentation UI |
 
-The core business logic that orchestrates embedding generation.
+### 2. Database Layer (`db.py`)
 
-- **Responsibilities:**
-  - Accept validated text inputs and model configuration
-  - Select the appropriate model provider based on the request or server defaults
-  - Optionally split inputs into provider-specific batch sizes
-  - Aggregate results from multiple batches
-  - Return normalised embedding vectors with metadata
-  - Handle provider failures with fallback logic (if configured)
+Manages a Postgres connection pool via `psycopg2` and provides:
 
-### 3. Model Provider Abstraction
+- **Schema initialisation** — Creates `jobs`, `index_meta`, and `embeddings`
+  tables with the `vector` extension on startup.
+- **Job CRUD** — Create, update, and poll indexing jobs with status tracking
+  (`queued → downloading → running → completed/failed`).
+- **Index metadata** — Stores which embedding model and dimension were used for
+  each project, enabling automatic model selection at query time.
+- **Embedding storage** — `upsert` semantics with `(namespace, project_id, chunk_id)`
+  uniqueness so re-indexing updates vectors in place.
 
-A pluggable interface that isolates the embedding engine from specific model APIs.
+The `embeddings` table stores `vector(768)` columns (CodeBERT dimension) with an
+IVFFlat cosine-similarity index. If the table was previously created with a
+different dimension it is automatically dropped and recreated.
 
-- **Interface:** All providers implement a common `Embedder` interface:
+### 3. File Scanning (`utils/file_scanner.py`)
 
-  ```go
-  // Embedder generates vector embeddings for a list of texts.
-  type Embedder interface {
-      // Embed returns embeddings for the given texts.
-      Embed(ctx context.Context, texts []string, opts EmbedOptions) (*EmbedResult, error)
+Walks a repository tree and yields source file paths. Prunes:
 
-      // ModelInfo returns metadata about the model (name, dimensions, max tokens).
-      ModelInfo() ModelInfo
-  }
-  ```
+- VCS directories (`.git`, `.svn`, `.hg`)
+- Dependency/build directories (`node_modules`, `vendor`, `__pycache__`, etc.)
+- Binary files by extension (images, archives, compiled files, lock files)
+- Generated files (`.min.js`, `.pb.go`, `_gen.go`, etc.)
+- Files larger than 512 KB
 
-- **Concrete providers:**
-  - `OpenAIEmbedder` — Calls the [OpenAI Embeddings API](https://platform.openai.com/docs/api-reference/embeddings) (`text-embedding-3-small`, `text-embedding-3-large`, `text-embedding-ada-002`)
-  - `HuggingFaceEmbedder` — Calls the [HuggingFace Inference API](https://huggingface.co/docs/api-inference) for hosted sentence-transformer models
-  - `LocalEmbedder` — Loads a HuggingFace model (e.g., via ONNX Runtime or a Go-native runtime) for offline inference
-  <!-- TODO: evaluate additional providers (Cohere, Voyage AI, Azure OpenAI) -->
+Supports an `include_dotfiles` mode for indexing dotfile repositories.
 
-### 4. Cache Layer
+### 4. Language Router (`utils/language_router.py`)
 
-An optional caching layer to avoid re-computing embeddings for identical inputs.
+Maps file paths to language names using a three-tier detection:
 
-- **Backends:**
-  - **In-memory** — Simple LRU cache for single-instance deployments (default)
-  - **Redis** — Distributed cache for multi-instance deployments
-- **Cache key:** Hash of `(model_id, text, dimensions)` to ensure correctness
-- **TTL:** Configurable, defaults to 1 hour
-- <!-- TODO: decide whether cache warming or pre-population is needed -->
+1. **Exact filename match** — Handles extensionless dotfiles (`.zshrc`,
+   `.gitconfig`, `Makefile`, `Dockerfile`, etc.)
+2. **Extension match** — `.py` → python, `.go` → go, `.rs` → rust, etc.
+3. **Shebang line** — Reads the first line for `#!/usr/bin/env python` etc.
 
-### 5. Configuration
+Dispatches to the appropriate analyzer function.
 
-Manages service settings from environment variables and/or config files.
+### 5. Analyzers (`analyzers/`)
 
-- **Sources** (in order of precedence):
-  1. Environment variables
-  2. Configuration file (`config.yaml` in the working directory)
-  3. Built-in defaults
-- **Hot-reload:** <!-- TODO: decide whether config hot-reload is needed -->
-- Settings include: listen address, default model, dimensions, cache config, provider API keys, and logging level.
+Each analyzer parses a source file and returns a `FileAnalysis` containing:
+
+- **Functions** — Name, line, signature, docstring, params, return type
+- **Classes** — Name, line, docstring, kind (struct/interface/class/enum)
+- **Imports** — List of import paths
+- **Package** — Go package name, Python module path, etc.
+
+| Analyzer | Approach | Languages |
+|----------|----------|-----------|
+| `python_analyzer.py` | Python `ast` module | Python |
+| `go_analyzer.py` | tree-sitter-go | Go |
+| `js_analyzer.py` | tree-sitter-javascript | JavaScript, TypeScript |
+| `generic_ts_analyzer.py` | Config-driven tree-sitter | Rust, Java, Ruby, C, C++, Lua |
+| `shell_analyzer.py` | Regex patterns | Bash, zsh, fish |
+| `config_analyzer.py` | stdlib parsers (PyYAML, tomllib, json, configparser) | YAML, TOML, JSON, INI, .env, .gitignore, etc. |
+
+The `generic_ts_analyzer` uses a `LanguageProfile` dataclass to describe each
+language's tree-sitter node types, name-extraction strategies, and doc comment
+types. Adding a new tree-sitter language only requires adding a profile dict.
+
+### 6. Chunker (`lib/chunker.py`)
+
+Breaks each `FileAnalysis` into embedding-ready chunks:
+
+1. **Imports chunk** — All import statements from the file
+2. **Function chunks** — One per function/method, including the function body
+   with surrounding context lines
+3. **Class chunks** — One per class/struct/interface with its body
+4. **File summary chunk** — Compact overview listing all symbols and imports
+5. **Full-file fallback** — If no symbols were extracted, the entire file is
+   chunked as-is
+
+Each chunk carries rich metadata: file path, language, symbol name, signature,
+docstring, params, return type, line number, package, and graph relationships.
+
+### 7. Graph Builder (`lib/graph.py`)
+
+Builds two complementary graphs from the parsed analyses:
+
+**Import graph** (file-level):
+- `depends_on` — Local files this file imports
+- `imported_by` — Local files that import this file
+- Resolves Python dotted imports, JS relative paths, and Go package paths
+
+**Call graph** (symbol-level):
+- `calls` — Local functions this function calls
+- `called_by` — Local functions that call this function
+- `external_calls` — Unresolved calls (stdlib/third-party)
+- Built for Python (via `ast.walk`), Go (via tree-sitter), and JS (via tree-sitter)
+
+Both graphs are injected into chunk metadata so search results carry relational
+context. The LLM can answer questions like "What calls `authenticate()`?" or
+"What does `UserService.Create` depend on?".
+
+### 8. Embedder (`lib/embedder.py`)
+
+Two embedding strategies, selected automatically based on codebase size:
+
+**Local: `CodeEmbedder`** (microsoft/codebert-base)
+- 768-dimensional vectors
+- Uses HuggingFace transformers with masked mean pooling
+- No API key required
+- Falls back to `sentence-transformers` for non-CodeBERT models
+- Further fallback to random embeddings if nothing is available
+
+**Cloud: `VoyageEmbedder`** (voyage-code-3)
+- 1024-dimensional vectors
+- REST API calls to Voyage AI
+- Requires `VOYAGE_API_KEY` environment variable
+- Batched requests (128 texts per API call)
+- Used when the codebase produces more than `LARGE_CODEBASE_THRESHOLD` chunks
+
+The threshold is configurable via the `LARGE_CODEBASE_THRESHOLD` constant
+(default: 99 999 chunks). This ensures small repos index quickly with no
+external dependency, while large repos benefit from a superior code embedding
+model.
+
+### 9. Vector Stores (`store/`)
+
+#### pgvector Store (`store/pgvector_store.py`) — Primary
+
+- Stores embeddings as `vector(768)` columns in Postgres
+- Uses `psycopg2.extras.execute_values` for batched upserts (200 rows/batch)
+- Deterministic chunk IDs via MD5 hash of `(file_path, chunk_type, symbol_name, line_number)`
+- `replace_all` mode: upserts new vectors then deletes stale ones from previous runs
+- Cosine-similarity search via IVFFlat index (`embedding <=> query_vector`)
+- Returns `(metadata, similarity_score, rank)` tuples
+
+#### Chroma Store (`store/chroma_store.py`) — Alternative
+
+- Embedded ChromaDB with SQLite persistence
+- Same interface as the pgvector store
+- Handles ChromaDB's `SQLITE_READONLY_DBMOVED` pitfalls with a single shared
+  `PersistentClient` per directory and careful collection management
+- JSON-encodes list metadata fields (Chroma only accepts scalars)
+- Used by the standalone `full_pipeline_chroma()` pipeline
+
+#### Project Store (`store/project_store.py`)
+
+- JSON-file-backed store for project metadata
+- Thread-safe with file locking
+- Independent of any vector index
+
+### 10. Web UI (`web/index.html`)
+
+A single-page API documentation site served at the root URL. Styled with custom
+CSS and provides interactive endpoint documentation with request/response
+examples, parameter tables, and copy-to-clipboard support.
 
 ## Data Flow
 
+### Indexing Pipeline
+
 ```
-┌──────────┐      ┌──────────────┐      ┌────────────────┐      ┌──────────────┐      ┌──────────────┐
-│  Client   │─────►│  API Layer   │─────►│   Request      │─────►│  Embedding   │─────►│  Model       │
-│           │      │  (HTTP)      │      │   Validation   │      │  Engine      │      │  Provider    │
-└──────────┘      └──────────────┘      └────────────────┘      └──────────────┘      └──────────────┘
-                                                                                             │
-                                                                                             ▼
-┌──────────┐      ┌──────────────┐      ┌────────────────┐      ┌──────────────┐      ┌──────────────┐
-│  Client   │◄─────│  API Layer   │◄─────│   Response     │◄─────│  Embedding   │◄─────│  Vectors     │
-│           │      │  (JSON)      │      │   Serialiser   │      │  Engine      │      │  (float[])   │
-└──────────┘      └──────────────┘      └────────────────┘      └──────────────┘      └──────────────┘
+Repository
+  │
+  ├─ 1. File Scanner ─── walk tree, filter by extension/size
+  │
+  ├─ 2. Language Router ─ map each file → language name
+  │
+  ├─ 3. Analyzers ─── parse AST, extract FileAnalysis
+  │     (functions, classes, imports, docstrings)
+  │
+  ├─ 4. Graph Builder
+  │     ├─ Import graph (file-level dependencies)
+  │     └─ Call graph (symbol-level callers/callees)
+  │
+  ├─ 5. Chunker ─── split into embedding-ready chunks
+  │     (inject graph data into each chunk's metadata)
+  │
+  ├─ 6. Embedder ─── generate vectors
+  │     ├─ ≤ threshold → CodeBERT (local, 768-d)
+  │     └─ > threshold → Voyage AI (cloud, 1024-d)
+  │
+  └─ 7. Vector Store ─── upsert into Postgres/pgvector
+        (with index metadata for model auto-detection)
 ```
 
-### Step-by-step
+### Search Query Flow
 
-1. **Request received** — The API layer receives a `POST /v1/embed` request with a JSON body containing `texts`, an optional `model`, and optional `dimensions`.
+```
+Client sends POST /search/text { namespace, project_id, query }
+  │
+  ├─ 1. Read index_meta from DB ─ determine which model was used
+  │
+  ├─ 2. Embed the query text with the correct model
+  │     (VoyageEmbedder or CodeEmbedder)
+  │
+  ├─ 3. Search pgvector ─ cosine similarity ORDER BY LIMIT k
+  │
+  └─ 4. Return results with metadata, similarity scores, and ranks
+```
 
-2. **Validation** — The request body is validated:
-   - `texts` must be a non-empty array of strings.
-   - Each text must not exceed the model's maximum input token length.
-   - `dimensions` (if provided) must be within the model's supported range.
-   - On failure, a `400 INVALID_REQUEST` error is returned immediately.
+### Dimension Mismatch Handling
 
-3. **Cache lookup** — If caching is enabled, the cache is queried for each input text using a key derived from `(model, text, dimensions)`. Cached results are returned without calling the provider.
+The `/search` endpoint accepts a pre-computed embedding. If the dimension
+doesn't match the stored index, the server checks for an accompanying `text`
+field. If present, it re-embeds the text with the correct model automatically
+instead of returning an error. This transparent fallback means callers don't
+need to track which embedder was used at index time.
 
-4. **Provider selection** — The embedding engine resolves the requested model to a configured provider. If no model is specified, the server default is used. If the model is not available, a `422 MODEL_NOT_FOUND` error is returned.
+## Database Schema
 
-5. **Batch embedding** — The provider's `Embed()` method is called with the validated texts (minus any cache hits). The provider may internally batch the request if it exceeds its per-request limit.
+```sql
+-- Indexing jobs
+CREATE TABLE jobs (
+    job_id TEXT PRIMARY KEY,
+    namespace TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    filename TEXT,
+    status TEXT NOT NULL,           -- queued | downloading | running | completed | failed
+    source TEXT,                    -- github | local | upload
+    owner TEXT,
+    repo TEXT,
+    ref TEXT,
+    total_vectors INTEGER,
+    persist_dir TEXT,
+    embedder TEXT,
+    webhook_url TEXT,
+    error TEXT,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL
+);
 
-6. **Response construction** — The embedding engine assembles the response:
-   - Merges cache hits with fresh provider results.
-   - Returns the embeddings in the same order as the input texts.
-   - Attaches model metadata and usage information.
+-- Index metadata (which model/dimension was used)
+CREATE TABLE index_meta (
+    namespace TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    embedder TEXT,                  -- CodeEmbedder | VoyageEmbedder
+    model TEXT,                     -- microsoft/codebert-base | voyage-code-3
+    embedding_dim INTEGER,          -- 768 | 1024
+    use_cloud BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (namespace, project_id)
+);
 
-7. **Cache write** — Fresh results are written to the cache with the configured TTL.
+-- Embedding vectors with metadata
+CREATE TABLE embeddings (
+    id BIGSERIAL PRIMARY KEY,
+    namespace TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    chunk_id TEXT NOT NULL,         -- deterministic MD5 hash
+    file_path TEXT,
+    chunk_type TEXT,                -- function | class | imports | file_summary | file
+    symbol_name TEXT,
+    line_number INTEGER,
+    content TEXT,                   -- source text used for embedding
+    metadata JSONB,                 -- all chunk metadata as JSON
+    embedding vector(768),
+    created_at TIMESTAMPTZ NOT NULL,
+    UNIQUE (namespace, project_id, chunk_id)
+);
 
-8. **Response sent** — The API layer serialises the response as JSON and returns it to the client with a `200 OK` status.
+-- Cosine similarity index
+CREATE INDEX embeddings_vec_idx
+    ON embeddings USING ivfflat (embedding vector_cosine_ops);
+```
 
-```mermaid
-sequenceDiagram
-    participant C as Client
-    participant A as API Layer
-    participant V as Validator
-    participant E as Embedding Engine
-    participant Ca as Cache
-    participant P as Model Provider
+## Chunk Metadata Schema
 
-    C->>A: POST /v1/embed {texts, model, dimensions}
-    A->>V: Validate request body
-    V-->>A: Validation result (pass/fail)
-    alt Validation fails
-        A-->>C: 400 INVALID_REQUEST
-    end
-    A->>E: GenerateEmbeddings(texts, opts)
-    E->>Ca: Check cache for each text
-    Ca-->>E: Cache hits (if any)
-    E->>P: Embed(ctx, uncached_texts, opts)
-    P-->>E: Embeddings + usage metadata
-    E->>Ca: Store fresh results in cache
-    E-->>A: EmbedResult {embeddings, model, usage}
-    A-->>C: 200 OK {model, dimensions, embeddings, usage}
+Each chunk stored in pgvector carries a JSONB `metadata` object:
+
+```json
+{
+  "file_path": "src/auth/handler.go",
+  "language": "go",
+  "chunk_type": "function",
+  "symbol_type": "function",
+  "symbol_name": "AuthService.Login",
+  "function_name": "AuthService.Login",
+  "line_number": 42,
+  "signature": "func (s *AuthService) Login(ctx context.Context, creds Credentials) (*Token, error)",
+  "docstring": "Login authenticates a user and returns a JWT token.",
+  "params": ["ctx", "creds"],
+  "return_type": "",
+  "package": "auth",
+  "content": "... source text used for embedding ...",
+  "calls": ["AuthService.validateCredentials", "Token.Generate"],
+  "called_by": ["LoginHandler.ServeHTTP"],
+  "external_calls": ["log.Printf"],
+  "depends_on": ["src/auth/token.go"],
+  "imported_by": ["src/api/router.go"]
+}
 ```
 
 ## Technology Choices
 
-<!-- TODO: confirm the tech stack with the team before implementation begins -->
+| Component | Choice | Rationale |
+|-----------|--------|-----------|
+| **Language** | Python 3.10+ | Rich ML/embedding ecosystem, tree-sitter bindings, fast iteration |
+| **Web framework** | FastAPI | Async support, Pydantic validation, auto-generated docs |
+| **ASGI server** | Uvicorn | Production-grade async server for FastAPI |
+| **Database** | PostgreSQL + pgvector | Vector similarity search alongside relational data |
+| **ORM** | Raw psycopg2 | Direct control over queries, no abstraction overhead |
+| **Embeddings (local)** | microsoft/codebert-base | Good code understanding, no API needed, 768-d |
+| **Embeddings (cloud)** | Voyage AI voyage-code-3 | Superior code embeddings for large codebases, 1024-d |
+| **AST parsing** | tree-sitter + ast | Incremental, error-tolerant parsing for 12+ languages |
+| **Vector index** | IVFFlat (pgvector) | Good balance of index speed and recall |
+| **HTML UI** | Vanilla HTML/CSS/JS | Zero build step, single file, instant deployment |
 
-| Component | Proposed Choice | Rationale | Alternatives Considered |
-|---|---|---|---|
-| **Language** | Go 1.22+ | Fast compilation, single binary deployment, excellent concurrency support, low memory footprint | Python (rich ML ecosystem but heavier runtime), Rust (maximal performance but steeper learning curve) |
-| **HTTP Framework** | `net/http` + `chi` router | Go standard library for transport; `chi` adds lightweight routing, middleware, and context support without bloat | `gorilla/mux` (unmaintained), `gin` (more opinionated), `fiber` (requires different ecosystem) |
-| **Model Provider — Cloud** | OpenAI Embeddings API | Industry-standard, high quality, well-documented, supports dimension truncation | HuggingFace Inference API, Cohere, Voyage AI |
-| **Model Provider — Local** | ONNX Runtime (via `onnxruntime-go`) | Cross-platform, fast CPU/GPU inference, wide model support | Python subprocess (adds complexity), CGo bindings for C++ runtimes |
-| **Vector Cache** | In-memory LRU (default), Redis (distributed) | Zero dependencies for single-instance; Redis for production scale | Memcached (no native TTL-per-key), BadgerDB (embedded but overkill) |
-| **Configuration** | Environment variables + YAML file | 12-factor app compliance; file-based config for complex deployments | TOML, JSON (less human-readable), Viper (adds dependency weight) |
-| **Logging** | `log/slog` (Go 1.21+) | Structured logging in the standard library; no third-party dependency | `zap` (faster but external), `zerolog` (external) |
-| **Testing** | `testing` stdlib + `testify` | Standard library foundation; `testify` for assertions and mocks | `gomock` (generated mocks), `mockery` (more boilerplate) |
+## Multi-tenancy
 
-## Directory Structure
-
-<!-- TODO: adjust as the implementation evolves -->
-
-```
-embedder-service/
-├── cmd/
-│   └── server/
-│       └── main.go                 # Application entry point
-├── internal/
-│   ├── api/
-│   │   ├── handler.go              # HTTP route handlers
-│   │   ├── middleware.go           # CORS, logging, auth middleware
-│   │   ├── request.go              # Request types and validation
-│   │   └── response.go             # Response types and serialisation
-│   ├── embedder/
-│   │   ├── engine.go               # Embedding engine (orchestration)
-│   │   ├── embedder.go             # Embedder interface definition
-│   │   ├── openai.go               # OpenAI provider implementation
-│   │   ├── huggingface.go          # HuggingFace provider implementation
-│   │   ├── local.go                # Local model provider implementation
-│   │   └── registry.go             # Model name → provider registry
-│   ├── cache/
-│   │   ├── cache.go                # Cache interface
-│   │   ├── memory.go               # In-memory LRU cache
-│   │   └── redis.go                # Redis cache implementation
-│   └── config/
-│       ├── config.go               # Configuration struct and loader
-│       └── defaults.go             # Default values
-├── pkg/
-│   └── logger/
-│       └── logger.go               # Shared structured logger setup
-├── configs/
-│   └── config.yaml                 # Example configuration file
-├── docs/
-│   ├── api.yaml                    # OpenAPI / Swagger specification
-│   └── architecture.md             # This file
-├── scripts/
-│   └── dev.sh                      # Local development helper script
-├── go.mod                          # Go module definition
-├── go.sum                          # Dependency checksums
-├── Dockerfile                      # Container build
-├── .dockerignore                   # Docker build exclusions
-├── .gitignore                      # Git exclusions
-├── Makefile                        # Build, test, lint targets
-├── README.md                       # Project overview and usage
-└── LICENSE                         # License file
-```
-
-### Key Design Decisions
-
-- **`cmd/`** contains the application entry points. Multiple binaries (e.g., `server`, `migrate`) can live here.
-- **`internal/`** holds all private application code that cannot be imported by external Go modules. This is where the core business logic lives.
-- **`pkg/`** contains packages that could potentially be reused by other projects (e.g., a shared logger or utility library).
-- **`configs/`** stores configuration files and templates, separate from source code.
-- **`docs/`** holds documentation assets like the OpenAPI spec.
-- <!-- TODO: add a `test/` or `testdata/` directory for integration test fixtures -->
-
-## Deployment Considerations
-
-<!-- TODO: expand this section based on the team's infrastructure -->
-
-### Horizontal Scaling
-
-The stateless API design allows multiple instances to run behind a load balancer. For distributed caching, configure Redis as the cache backend.
-
-### Resource Requirements
-
-<!-- TODO: profile and document actual resource usage -->
-
-- **CPU:** Minimal for API and orchestration; depends on local model inference if enabled
-- **Memory:** ~50 MB base; increases with cache size and loaded models
-- **Network:** Outbound HTTPS to model provider APIs; no inbound dependencies
-
-### Observability
-
-<!-- TODO: add Prometheus metrics and distributed tracing once implementation begins -->
-
-- Structured JSON logs via `log/slog`
-- Health and readiness probes for container orchestrators
-- <!-- TODO: add Prometheus `/metrics` endpoint -->
-- <!-- TODO: add OpenTelemetry trace propagation -->
-
-## Security Considerations
-
-<!-- TODO: expand based on the team's security requirements -->
-
-- **API keys** — Provider API keys are loaded from environment variables and never exposed in responses or logs.
-- **Input sanitisation** — Text inputs are validated for length and encoding before being passed to embedding providers.
-- **Rate limiting** — <!-- TODO: implement rate limiting middleware -->
-- **TLS** — <!-- TODO: document TLS termination strategy (reverse proxy vs built-in) -->
+All data is scoped by `(namespace, project_id)`. This allows a single service
+instance to index and search across multiple organisations or repositories
+without data leakage. Queries always include both keys in the `WHERE` clause.

--- a/README.md
+++ b/README.md
@@ -1,244 +1,228 @@
-# Embedder Service
+# Code Indexer Service
 
-<!-- TODO: add project badges once CI/CD and licensing are configured -->
-<!-- [![Build Status](https://img.shields.io/github/actions/workflow/status/unitz007/embedder-service/ci.yml?branch=main)](https://github.com/unitz007/embedder-service/actions) -->
-<!-- [![Go Report Card](https://goreportcard.com/badge/github.com/unitz007/embedder-service)](https://goreportcard.com/report/github.com/unitz007/embedder-service) -->
-<!-- [![License](https://img.shields.io/github/license/unitz007/embedder-service)](./LICENSE) -->
+Semantic search infrastructure for codebases. Index any GitHub repository or local
+project, generate embeddings with CodeBERT or Voyage AI, and query with natural
+language over function signatures, docstrings, import graphs, and call graphs.
 
-A lightweight HTTP service that accepts text input and returns high-dimensional vector embeddings. Designed to plug into RAG pipelines, semantic search systems, and any application that needs to turn natural language or structured data into machine-readable vectors. The service abstracts over multiple embedding model providers (OpenAI, HuggingFace, local models, etc.) behind a simple RESTful API, making it easy to swap or compare models without changing downstream consumers.
+Built with **Python 3**, **FastAPI**, **Postgres/pgvector**, and **tree-sitter**.
 
 ## Features
 
-<!-- TODO: update this list once the implementation takes shape -->
-
-- **Simple REST API** — Send text, receive vectors. A single `POST /v1/embed` endpoint does the heavy lifting.
-- **Model provider abstraction** — Swap between OpenAI, HuggingFace, or locally-hosted models by changing configuration, not code.
-- **Batch support** — Embed multiple texts in a single request to reduce latency and network overhead.
-- **Configurable dimensions** — Control output vector dimensions via request parameters or server-side defaults.
-- **Health and readiness checks** — Built-in `/healthz` and `/readyz` endpoints for orchestration platforms.
+- **Multi-language AST analysis** — Parses Python, Go, JavaScript/TypeScript,
+  Rust, Java, Ruby, C, C++, Lua, shell scripts, and config files using
+  tree-sitter grammars and Python's `ast` module.
+- **Symbol extraction** — Extracts functions, methods, classes, structs,
+  interfaces, imports, and docstrings from each source file.
+- **Import & call graphs** — Builds file-level import dependency graphs and
+  symbol-level call graphs across the entire codebase.
+- **Semantic code search** — Embeds code chunks with
+  [microsoft/codebert-base](https://huggingface.co/microsoft/codebert-base)
+  (local, 768-d) or [Voyage AI voyage-code-3](https://docs.voyageai.com/)
+  (cloud, 1024-d) and stores them in Postgres/pgvector for cosine-similarity
+  search.
+- **Automatic model selection** — Uses the local CodeBERT embedder for small
+  codebases and automatically switches to Voyage AI for large ones.
+- **GitHub integration** — Clone and index public or private GitHub repos by
+  owner/repo with OAuth token support.
+- **Async job pipeline** — Indexing runs in background tasks with full job
+  lifecycle tracking (queued → downloading → running → completed/failed) and
+  webhook notifications.
+- **Dimension-mismatch handling** — The `/search/text` endpoint reads the
+  stored index metadata and automatically picks the correct embedding model at
+  query time, so callers never need to know which model was used at index time.
+- **Built-in web UI** — A single-page documentation and API explorer served at
+  the root URL.
 
 ## Quick Start
 
-<!-- TODO: fill in with actual build/run instructions once the project is bootstrapped -->
-
 ### Prerequisites
 
-- **Go 1.22+** (proposed default — see [Architecture](./ARCHITECTURE.md) for rationale)
-- <!-- TODO: add other prerequisites (Docker, model runtime, etc.) once confirmed -->
+- Python 3.10+
+- PostgreSQL with the [pgvector extension](https://github.com/pgvector/pgvector)
+- (Optional) A [Voyage AI API key](https://docs.voyageai.com/docs/api-key) for
+  indexing large codebases
 
-### Build
-
-```bash
-git clone https://github.com/unitz007/embedder-service.git
-cd embedder-service
-
-# Build the binary
-go build -o bin/embedder-service ./cmd/server
-
-# Or use Docker (once a Dockerfile is added)
-# docker build -t embedder-service .
-```
-
-### Run
+### Install dependencies
 
 ```bash
-# Start the server with default settings
-./bin/embedder-service
-
-# Or with environment variable overrides
-EMBEDDER_PORT=8080 EMBEDDER_MODEL=text-embedding-3-small ./bin/embedder-service
+pip install -r requirements.txt
 ```
 
-The server starts listening on `http://localhost:8080` by default.
+### Database setup
 
-### Docker
+```bash
+# Ensure the pgvector extension is available in your Postgres instance.
+# If using Supabase or a managed Postgres, it may already be installed.
 
-<!-- TODO: uncomment and adjust once a Dockerfile exists -->
+# Set the database connection URL:
+export DATABASE_URL="postgresql://user:password@localhost:5432/indexer"
 
-<!-- ```bash
-docker run -d \
-  -p 8080:8080 \
-  -e EMBEDDER_MODEL=text-embedding-3-small \
-  -e OPENAI_API_KEY=sk-... \
-  unitz007/embedder-service:latest
-``` -->
+# Or for local development without setting DATABASE_URL, the service
+# defaults to: postgresql://postgres:postgres@localhost:5432/indexer
+```
+
+### Run the service
+
+```bash
+uvicorn main:app --reload --port 8080
+```
+
+The API is available at `http://localhost:8080` and the web UI at the root URL.
+
+### Index a GitHub repository
+
+```bash
+curl -X POST http://localhost:8080/github/index \
+  -H "Content-Type: application/json" \
+  -d '{"owner": "vercel", "repo": "next.js"}'
+```
+
+Response:
+
+```json
+{
+  "status": "queued",
+  "job_id": "a3f9c1...",
+  "namespace": "vercel",
+  "project_id": "next.js"
+}
+```
+
+Poll the job status:
+
+```bash
+curl http://localhost:8080/jobs/a3f9c1...
+```
+
+### Search with natural language
+
+```bash
+curl -X POST http://localhost:8080/search/text \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "vercel",
+    "project_id": "next.js",
+    "query": "how does file-system routing work",
+    "k": 5
+  }'
+```
 
 ## API Overview
 
-<!-- TODO: finalise the OpenAPI schema and link it here -->
+All endpoints are documented in the built-in web UI. Here's a summary:
 
-All API endpoints are prefixed with `/v1`. The service accepts and returns JSON.
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| `POST` | `/github/index` | Open | Queue a GitHub repo or local path for indexing |
+| `POST` | `/embeddings/{ns}/{pid}` | Bearer | Upload a zip archive and index it |
+| `POST` | `/search/text` | Open | Search with raw query text (recommended) |
+| `POST` | `/search` | Open | Search with a pre-computed embedding vector |
+| `POST` | `/embed` | Open | Embed arbitrary text with the correct model |
+| `GET` | `/embeddings/{ns}/{pid}` | Bearer | Get index metadata and vector count |
+| `DELETE` | `/embeddings/{ns}/{pid}` | Bearer | Delete a project's index |
+| `GET` | `/jobs/{job_id}` | Bearer | Poll indexing job status |
 
-### `POST /v1/embed`
+### Authentication
 
-Generate embedding vectors for one or more text inputs.
-
-**Request body:**
-
-```json
-{
-  "texts": ["Hello, world!", "How does embedding work?"],
-  "model": "text-embedding-3-small",
-  "dimensions": 1536
-}
-```
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `texts` | `string[]` | Yes | One or more text strings to embed (max batch size TBD) |
-| `model` | `string` | No | Model identifier to use. Overrides the server default. |
-| `dimensions` | `integer` | No | Desired output dimensions. Model-dependent; may be ignored. |
-
-**Response (200 OK):**
-
-```json
-{
-  "model": "text-embedding-3-small",
-  "dimensions": 1536,
-  "embeddings": [
-    [0.0023, -0.0141, 0.0387, "..."],
-    [-0.0082, 0.0255, -0.0019, "..."]
-  ],
-  "usage": {
-    "prompt_tokens": 12,
-    "total_tokens": 12
-  }
-}
-```
-
-| Field | Type | Description |
-|---|---|---|
-| `model` | `string` | The model that was used to generate embeddings |
-| `dimensions` | `integer` | Dimensionality of each embedding vector |
-| `embeddings` | `float[][]` | Array of embedding vectors, one per input text |
-| `usage` | `object` | Token usage information (provider-specific) |
-
-**Error responses:**
-
-| Status | Code | Description |
-|---|---|---|
-| 400 | `INVALID_REQUEST` | Request body is malformed or missing required fields |
-| 422 | `MODEL_NOT_FOUND` | The requested model is not configured or available |
-| 429 | `RATE_LIMITED` | Too many requests — retry after the `Retry-After` header |
-| 500 | `INTERNAL_ERROR` | An unexpected error occurred during embedding |
-
-### `GET /healthz`
-
-Liveness probe. Returns `200 OK` if the server process is running.
-
-### `GET /readyz`
-
-Readiness probe. Returns `200 OK` if the server is ready to accept requests (model loaded, dependencies available).
-
-### `GET /v1/models`
-
-<!-- TODO: implement once model registry is built -->
-
-Returns a list of available embedding models and their metadata.
-
-```json
-{
-  "models": [
-    {
-      "id": "text-embedding-3-small",
-      "provider": "openai",
-      "dimensions": 1536,
-      "max_input_tokens": 8191
-    }
-  ]
-}
-```
+Most endpoints are open. Management endpoints (upload, delete, status) require
+an `Authorization: Bearer <token>` header. The token value is not validated
+against any specific identity — it simply must be present.
 
 ## Configuration
 
-<!-- TODO: confirm the final configuration schema once implementation begins -->
-
-The service is configured via environment variables. All variables have sensible defaults for local development.
-
 | Variable | Description | Default |
-|---|---|---|
-| `EMBEDDER_PORT` | HTTP listen port | `8080` |
-| `EMBEDDER_HOST` | HTTP listen address | `0.0.0.0` |
-| `EMBEDDER_MODEL` | Default embedding model identifier | `text-embedding-3-small` |
-| `EMBEDDER_DIMENSIONS` | Default output dimensions | `1536` |
-| `EMBEDDER_LOG_LEVEL` | Log verbosity (`debug`, `info`, `warn`, `error`) | `info` |
-| `EMBEDDER_MAX_BATCH_SIZE` | Maximum number of texts per request | `64` |
-| `OPENAI_API_KEY` | API key for OpenAI provider | — |
-| `HUGGINGFACE_API_KEY` | API key for HuggingFace Inference API | — |
-| `OPENAI_BASE_URL` | Override OpenAI API base URL (for proxies) | — |
-| `CACHE_ENABLED` | Enable response caching | `false` |
-| `CACHE_TTL` | Cache time-to-live in seconds | `3600` |
-| `CACHE_BACKEND` | Cache backend (`memory`, `redis`) | `memory` |
-| `REDIS_URL` | Redis connection URL (when `CACHE_BACKEND=redis`) | `localhost:6379` |
+|----------|-------------|---------|
+| `DATABASE_URL` | Postgres connection string | `postgresql://postgres:postgres@localhost:5432/indexer` |
+| `LOCAL_DATABASE_URL` | Fallback for non-prod environments | (same as `DATABASE_URL`) |
+| `APP_ENV` | Application environment (`dev`, `prod`) | `dev` |
+| `VOYAGE_API_KEY` | Voyage AI API key (for large codebases) | — |
+| `WEBHOOK_SECRET` | HMAC secret for webhook notifications | — |
+| `GITHUB_API_BASE` | GitHub API base URL | `https://api.github.com` |
+| `GITHUB_API_VERSION` | GitHub API version header | `2022-11-28` |
+| `DB_POOL_MAX` | Postgres connection pool size | `20` |
 
-### Configuration File
+## Supported Languages
 
-<!-- TODO: decide on config file format (YAML, TOML, env) and document -->
+| Language | Parser | Extracts |
+|----------|--------|----------|
+| Python | `ast` (stdlib) | Functions, async functions, classes, methods, imports, docstrings |
+| Go | tree-sitter-go | Functions, methods (with receiver), structs, interfaces, type aliases, imports |
+| JavaScript / TypeScript | tree-sitter-javascript | Function declarations, arrow functions, classes, methods, exports, imports |
+| Rust | tree-sitter-rust | Functions, impl methods, structs, enums, traits, use declarations |
+| Java | tree-sitter-java | Methods, constructors, classes, interfaces, enums, imports |
+| Ruby | tree-sitter-ruby | Methods, singleton methods, classes, modules, requires |
+| C | tree-sitter-c | Functions, structs, enums, unions, `#include` directives |
+| C++ | tree-sitter-cpp | Functions, classes, structs, namespaces, enums, `#include` directives |
+| Lua | tree-sitter-lua | Functions, local functions, require calls |
+| Shell (bash/zsh/fish) | Regex | Functions, aliases, exports, source/include paths |
+| Config files | stdlib parsers | Sections, key-value pairs (YAML, TOML, JSON, INI, .env, .gitignore, etc.) |
 
-A configuration file can be used as an alternative to environment variables. The service looks for `config.yaml` in the working directory by default. Environment variables take precedence over file values.
+## Project Structure
+
+```
+.
+├── main.py                     # FastAPI application and all HTTP endpoints
+├── db.py                       # Postgres connection pool, schema init, CRUD
+├── models.py                   # Dataclasses: FileAnalysis, FunctionInfo, ClassInfo
+├── requirements.txt            # Python dependencies
+├── analyzers/                  # Per-language AST/symbol analyzers
+│   ├── python_analyzer.py      #   Python (ast module)
+│   ├── go_analyzer.py          #   Go (tree-sitter)
+│   ├── js_analyzer.py          #   JavaScript (tree-sitter)
+│   ├── generic_ts_analyzer.py  #   Rust, Java, Ruby, C, C++, Lua (config-driven)
+│   ├── shell_analyzer.py       #   Bash/zsh/fish (regex)
+│   └── config_analyzer.py      #   YAML, TOML, JSON, INI, .env, etc.
+├── indexing/
+│   ├── full_pipeline.py        # Orchestrates: scan → parse → chunk → embed → store
+│   └── USAGE_GUIDE.md          # Standalone LLM analysis guide
+├── lib/
+│   ├── chunker.py              # Splits FileAnalysis into embedding-ready chunks
+│   ├── embedder.py             # CodeBERT (local) and Voyage AI (cloud) embedders
+│   ├── graph.py                # Import graph and call graph builders
+│   └── indexer.py              # Thin wrapper: scan + analyze
+├── store/
+│   ├── pgvector_store.py       # pgvector-backed vector store (primary)
+│   ├── chroma_store.py         # ChromaDB-backed vector store (alternative)
+│   └── project_store.py        # JSON-file project metadata store
+├── utils/
+│   ├── file_scanner.py         # Repository walker with ignore rules
+│   └── language_router.py      # File extension → language → analyzer dispatch
+├── web/
+│   └── index.html              # Built-in API documentation UI
+├── .dockerignore
+├── .gitignore
+└── ARCHITECTURE.md             # Detailed architecture documentation
+```
+
+## How Indexing Works
+
+1. **Scan** — Walk the repository, skip VCS/build/generated files (configurable
+   ignore rules in `utils/file_scanner.py`).
+2. **Detect language** — Map each file to a language via its extension or name
+   (`utils/language_router.py`).
+3. **Analyze** — Run the appropriate parser to extract functions, classes,
+   imports, and docstrings into `FileAnalysis` objects.
+4. **Build graphs** — Construct a file-level import graph and a symbol-level
+   call graph across the entire codebase (`lib/graph.py`).
+5. **Chunk** — Split each file into embedding-ready chunks: one per function,
+   one per class, one for imports, and a file-level summary (`lib/chunker.py`).
+   Graph metadata (callers, callees, dependencies) is injected into each chunk.
+6. **Embed** — Generate vector embeddings. Small codebases use local CodeBERT
+   (768-d); large ones use Voyage AI voyage-code-3 (1024-d) (`lib/embedder.py`).
+7. **Store** — Upsert vectors into Postgres/pgvector with cosine-similarity
+   indexing (`store/pgvector_store.py`). Metadata includes file path, symbol
+   name, signature, docstring, params, return type, and graph relationships.
 
 ## Development
 
-<!-- TODO: fill in with concrete instructions once the project structure is bootstrapped -->
-
-### Project Layout
-
-See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full directory structure proposal.
-
-### Building
-
 ```bash
-# Build the server binary
-go build -o bin/embedder-service ./cmd/server
+# Run with auto-reload
+uvicorn main:app --reload
 
-# Build with race detector
-go build -race -o bin/embedder-service ./cmd/server
+# Run on a different port
+uvicorn main:app --port 3000
 ```
-
-### Testing
-
-```bash
-# Run all tests
-go test ./...
-
-# Run tests with verbose output and coverage
-go test -v -coverprofile=coverage.out ./...
-go tool cover -html=coverage.out
-```
-
-### Linting
-
-```bash
-# Lint the codebase
-golangci-lint run ./...
-
-# Format code
-gofmt -w .
-```
-
-### Running Locally
-
-```bash
-# Run directly with go run
-go run ./cmd/server
-
-# Or with hot-reload using air (once configured)
-air
-```
-
-## Links
-
-<!-- TODO: add real links as the project matures -->
-
-- [Architecture Documentation](./ARCHITECTURE.md)
-- [GitHub Repository](https://github.com/unitz007/embedder-service)
-- [Issues](https://github.com/unitz007/embedder-service/issues)
-<!-- - [API Reference (Swagger/OpenAPI)](./docs/api.yaml) -->
-<!-- - [Contributing Guide](./CONTRIBUTING.md) -->
-<!-- - [Changelog](./CHANGELOG.md) -->
 
 ## License
 
-<!-- TODO: add a LICENSE file and update this section -->
-
-This project is licensed under the [MIT License](./LICENSE).
+This project is licensed under the MIT License.


### PR DESCRIPTION
## Summary

The existing `README.md` and `ARCHITECTURE.md` described a planned **Go embedder-service** (`cmd/server`, `internal/`, `pkg/`) that was never implemented. The actual codebase is a **Python/FastAPI code indexer** with:

- Multi-language AST analysis via tree-sitter (12+ languages)
- Import and call graph construction
- Dual embedding models (local CodeBERT + cloud Voyage AI)
- Postgres/pgvector storage with IVFFlat cosine similarity
- Async job pipeline for GitHub/local indexing with webhook notifications
- Built-in web UI for API documentation

Both files have been completely rewritten from scratch, based on a thorough reading of every source file in the repository.

### `README.md` changes
- Updated project description, tech stack, and feature list
- Added Quick Start with actual commands (uvicorn, curl examples)
- Documented the real API endpoints with a summary table
- Added Configuration section with actual env vars from `main.py` / `db.py`
- Added Supported Languages table covering all 12+ languages
- Added actual Project Structure reflecting the real directory layout
- Added "How Indexing Works" pipeline overview

### `ARCHITECTURE.md` changes
- Rewrote overview with a Mermaid diagram of the actual architecture
- Documented all 10 core components with details from source code
- Added data flow diagrams for indexing and search query paths
- Explained dimension-mismatch handling
- Added complete database schema (DDL for jobs, index_meta, embeddings tables)
- Added chunk metadata schema example showing all enriched fields
- Updated technology choices table to match the real stack
- Added multi-tenancy section

### No code changes — documentation only.