### PR TITLE
feat: add semantic embedding cache to avoid redundant API/cuda calls

### DIFF
--- a/db.py
+++ b/db.py
@@ -72,7 +72,14 @@ def init_db() -> None:
                 )
                 """
             )
+            # Add columns that may not exist on older databases.
+            # embedder is already in CREATE TABLE above but the ALTER is
+            # harmless for fresh installs and needed for existing DBs where
+            # the column was added via ALTER originally.
             cur.execute("ALTER TABLE jobs ADD COLUMN IF NOT EXISTS embedder TEXT")
+            cur.execute("ALTER TABLE jobs ADD COLUMN IF NOT EXISTS model TEXT")
+            cur.execute("ALTER TABLE jobs ADD COLUMN IF NOT EXISTS embedding_dim INTEGER")
+            cur.execute("ALTER TABLE jobs ADD COLUMN IF NOT EXISTS use_cloud BOOLEAN DEFAULT FALSE")
             cur.execute(
                 """
                 CREATE TABLE IF NOT EXISTS index_meta (
@@ -237,33 +244,45 @@ def cache_store_embeddings(
 
 # ── Job helpers ────────────────────────────────────────────────────────────
 
+# Canonical list of columns for the jobs table.  Used by _row_to_job() and
+# the RETURNING clauses so that every query returns the same shape.
+_JOB_COLUMNS = [
+    "job_id",
+    "namespace",
+    "project_id",
+    "filename",
+    "status",
+    "source",
+    "owner",
+    "repo",
+    "ref",
+    "total_vectors",
+    "persist_dir",
+    "embedder",
+    "model",
+    "embedding_dim",
+    "use_cloud",
+    "webhook_url",
+    "error",
+    "created_at",
+    "updated_at",
+]
+
+
 def _row_to_job(row) -> Dict[str, Any]:
     if not row:
         return {}
-    keys = [
-        "job_id",
-        "namespace",
-        "project_id",
-        "filename",
-        "status",
-        "source",
-        "owner",
-        "repo",
-        "ref",
-        "total_vectors",
-        "persist_dir",
-        "embedder",
-        "webhook_url",
-        "error",
-        "created_at",
-        "updated_at",
-    ]
-    job = dict(zip(keys, row))
+    job = dict(zip(_JOB_COLUMNS, row))
     if isinstance(job.get("created_at"), datetime):
         job["created_at"] = job["created_at"].isoformat() + "Z"
     if isinstance(job.get("updated_at"), datetime):
         job["updated_at"] = job["updated_at"].isoformat() + "Z"
     return job
+
+
+def _JOB_RETURNING_CLAUSE() -> str:
+    """SQL fragment listing all job columns for RETURNING clauses."""
+    return ", ".join(_JOB_COLUMNS)
 
 
 def create_job(
@@ -280,20 +299,18 @@ def create_job(
     repo: Optional[str] = None,
     ref: Optional[str] = None,
 ) -> Dict[str, Any]:
+    returning = _JOB_RETURNING_CLAUSE()
     conn = get_pool().getconn()
     try:
         with conn.cursor() as cur:
             cur.execute(
-                """
+                f"""
                 INSERT INTO jobs (
                     job_id, namespace, project_id, filename, status,
                     source, owner, repo, ref, webhook_url,
                     created_at, updated_at
                 ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
-                RETURNING job_id, namespace, project_id, filename, status,
-                          source, owner, repo, ref, total_vectors,
-                          persist_dir, embedder, webhook_url, error,
-                          created_at, updated_at
+                RETURNING {returning}
                 """,
                 (
                     job_id, namespace, project_id, filename, status,
@@ -319,6 +336,7 @@ def update_job(job_id: str, **updates) -> Dict[str, Any]:
         values.append(v)
     values.append(job_id)
 
+    returning = _JOB_RETURNING_CLAUSE()
     conn = get_pool().getconn()
     try:
         with conn.cursor() as cur:
@@ -327,10 +345,7 @@ def update_job(job_id: str, **updates) -> Dict[str, Any]:
                 UPDATE jobs
                 SET {", ".join(fields)}
                 WHERE job_id = %s
-                RETURNING job_id, namespace, project_id, filename, status,
-                          source, owner, repo, ref, total_vectors,
-                          persist_dir, embedder, webhook_url, error,
-                          created_at, updated_at
+                RETURNING {returning}
                 """,
                 values,
             )
@@ -342,15 +357,13 @@ def update_job(job_id: str, **updates) -> Dict[str, Any]:
 
 
 def get_job(job_id: str) -> Dict[str, Any]:
+    returning = _JOB_RETURNING_CLAUSE()
     conn = get_pool().getconn()
     try:
         with conn.cursor() as cur:
             cur.execute(
-                """
-                SELECT job_id, namespace, project_id, filename, status,
-                       source, owner, repo, ref, total_vectors,
-                       persist_dir, embedder, webhook_url, error,
-                       created_at, updated_at
+                f"""
+                SELECT {returning}
                 FROM jobs
                 WHERE job_id = %s
                 """,
@@ -388,6 +401,7 @@ def update_job_index_meta(
     fields_sql = ", ".join(f"{k} = %s" for k in safe_fields)
     values = list(safe_fields.values())
 
+    returning = _JOB_RETURNING_CLAUSE()
     conn = get_pool().getconn()
     try:
         with conn.cursor() as cur:
@@ -401,10 +415,7 @@ def update_job_index_meta(
                     ORDER BY created_at DESC
                     LIMIT 1
                 )
-                RETURNING job_id, namespace, project_id, filename, status,
-                          source, owner, repo, ref, total_vectors,
-                          persist_dir, embedder, webhook_url, error,
-                          created_at, updated_at
+                RETURNING {returning}
                 """,
                 values + [namespace, project_id],
             )

--- a/db.py
+++ b/db.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List, Tuple
 
 import psycopg2
 from psycopg2.pool import ThreadedConnectionPool
@@ -124,10 +124,113 @@ def init_db() -> None:
                 ON embeddings USING ivfflat (embedding vector_cosine_ops)
                 """
             )
+
+            # ── Embedding cache table ──────────────────────────────────
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS embedding_cache (
+                    content_hash BYTEA NOT NULL,
+                    model_name   TEXT    NOT NULL,
+                    embedding    vector  NOT NULL,
+                    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    PRIMARY KEY (content_hash, model_name)
+                )
+                """
+            )
+            cur.execute(
+                """
+                CREATE INDEX IF NOT EXISTS embedding_cache_model_idx
+                ON embedding_cache (model_name)
+                """
+            )
+
             conn.commit()
     finally:
         get_pool().putconn(conn)
 
+
+# ── Embedding cache helpers ────────────────────────────────────────────────
+
+def cache_get_embeddings(
+    hashes_and_models: List[Tuple[bytes, str]],
+) -> Dict[bytes, List[float]]:
+    """Batch-fetch cached embeddings.
+
+    Args:
+        hashes_and_models: List of ``(content_hash, model_name)`` tuples.
+
+    Returns:
+        Dict mapping ``content_hash`` (bytes) → embedding (list of floats).
+        Only hashes that were found in the cache are included.
+    """
+    if not hashes_and_models:
+        return {}
+
+    # Deduplicate input — same (hash, model) pair may appear multiple times
+    unique_keys = list(set(hashes_and_models))
+
+    # Build a composite VALUES clause for a single query.
+    # psycopg2 %s placeholders work with BYTEA and TEXT transparently.
+    rows = ", ".join("(%s, %s)" for _ in unique_keys)
+    sql = f"""
+        SELECT content_hash, embedding
+        FROM embedding_cache
+        WHERE (content_hash, model_name) IN ({rows})
+    """
+    flat_args = []
+    for h, m in unique_keys:
+        flat_args.extend([h, m])
+
+    conn = get_pool().getconn()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql, flat_args)
+            result: Dict[bytes, List[float]] = {}
+            for content_hash, embedding in cur.fetchall():
+                # pgvector returns the vector as a list of floats
+                if isinstance(embedding, str):
+                    # Strip brackets and parse
+                    result[content_hash] = [float(x) for x in embedding.strip("[]").split(",")]
+                else:
+                    result[content_hash] = list(embedding)
+            return result
+    finally:
+        get_pool().putconn(conn)
+
+
+def cache_store_embeddings(
+    rows: List[Tuple[bytes, str, List[float]]],
+) -> None:
+    """Batch-insert embeddings into the cache.
+
+    Args:
+        rows: List of ``(content_hash, model_name, embedding_list)`` tuples.
+              Items whose key already exists are silently ignored (ON CONFLICT DO NOTHING).
+    """
+    if not rows:
+        return
+
+    from psycopg2.extras import execute_values
+
+    conn = get_pool().getconn()
+    try:
+        with conn.cursor() as cur:
+            execute_values(
+                cur,
+                """
+                INSERT INTO embedding_cache (content_hash, model_name, embedding)
+                VALUES %s
+                ON CONFLICT (content_hash, model_name) DO NOTHING
+                """,
+                rows,
+                template="(%s, %s, %s::vector)",
+            )
+            conn.commit()
+    finally:
+        get_pool().putconn(conn)
+
+
+# ── Job helpers ────────────────────────────────────────────────────────────
 
 def _row_to_job(row) -> Dict[str, Any]:
     if not row:

--- a/db.py
+++ b/db.py
@@ -126,6 +126,11 @@ def init_db() -> None:
             )
 
             # ── Embedding cache table ──────────────────────────────────
+            # The embedding column uses an untyped vector (no dimension)
+            # because the PK is (content_hash, model_name), guaranteeing
+            # that any given row's vector is always consumed with the
+            # correct model.  A fixed dimension would break multi-model
+            # caching (e.g. CodeBERT 768-d vs Voyage 1024-d).
             cur.execute(
                 """
                 CREATE TABLE IF NOT EXISTS embedding_cache (
@@ -353,6 +358,59 @@ def get_job(job_id: str) -> Dict[str, Any]:
             )
             row = cur.fetchone()
             return _row_to_job(row)
+    finally:
+        get_pool().putconn(conn)
+
+
+def update_job_index_meta(
+    namespace: str,
+    project_id: str,
+    data: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Update embedder-related metadata on the most recent job for a project.
+
+    This is a best-effort helper: if no job exists for the given
+    ``(namespace, project_id)`` pair the function returns an empty dict
+    without raising.
+    """
+    if not data:
+        return {}
+
+    # Only allow known columns to prevent SQL injection via key names.
+    allowed = {
+        "embedder", "model", "embedding_dim", "use_cloud",
+        "total_vectors", "updated_at",
+    }
+    safe_fields = {k: v for k, v in data.items() if k in allowed}
+    if not safe_fields:
+        return {}
+
+    fields_sql = ", ".join(f"{k} = %s" for k in safe_fields)
+    values = list(safe_fields.values())
+
+    conn = get_pool().getconn()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""
+                UPDATE jobs
+                SET {fields_sql}
+                WHERE job_id = (
+                    SELECT job_id FROM jobs
+                    WHERE namespace = %s AND project_id = %s
+                    ORDER BY created_at DESC
+                    LIMIT 1
+                )
+                RETURNING job_id, namespace, project_id, filename, status,
+                          source, owner, repo, ref, total_vectors,
+                          persist_dir, embedder, webhook_url, error,
+                          created_at, updated_at
+                """,
+                values + [namespace, project_id],
+            )
+            row = cur.fetchone()
+            conn.commit()
+            return _row_to_job(row) if row else {}
     finally:
         get_pool().putconn(conn)
 

--- a/indexing/full_pipeline.py
+++ b/indexing/full_pipeline.py
@@ -16,6 +16,7 @@ from lib.embedder import (
     embed_repository_chunks,
     CodeEmbedder,
     VoyageEmbedder,
+    EmbeddingCache,
     LARGE_CODEBASE_THRESHOLD,
     EMBEDDING_DIM,
     VOYAGE_EMBEDDING_DIM,
@@ -72,7 +73,6 @@ def chunk_analyses(analyses: List[Any]) -> List[Dict[str, Any]]:
     print(f"Created {len(chunks)} code chunks")
     return chunks
 
-
 def generate_embeddings(
     chunks: List[Dict[str, Any]],
     model_name: str = "microsoft/codebert-base",
@@ -89,7 +89,6 @@ def generate_embeddings(
     if embedder is not None:
         return embedder.embed_chunks(chunks)
     return embed_repository_chunks(chunks, model_name)
-
 
 def search_code(
     vector_store,
@@ -140,6 +139,7 @@ def full_pipeline_chroma(
     graphs_prefix: str = None,
     model_name: str = "microsoft/codebert-base",
     include_dotfiles: bool = False,
+    cache: Optional[EmbeddingCache] = None,
 ) -> tuple:
     """
     Run the complete pipeline and store vectors in Chroma instead of FAISS.
@@ -155,6 +155,8 @@ def full_pipeline_chroma(
                           land next to the Chroma dir.
         model_name:       Embedding model (sentence-transformers).
         include_dotfiles: Include hidden files.
+        cache:            Optional EmbeddingCache for reusing previously
+                          computed embeddings across runs.
 
     Returns:
         Tuple of (ChromaStore, call_graph dict, import_graph dict)
@@ -163,6 +165,10 @@ def full_pipeline_chroma(
 
     if graphs_prefix is None:
         graphs_prefix = str(Path(chroma_dir).parent / "vector_store")
+
+    # Create a cache if none was supplied — enables semantic reuse by default
+    if cache is None:
+        cache = EmbeddingCache()
 
     print(f"Starting Chroma pipeline for repository: {repo_path}")
     print("=" * 50)
@@ -189,12 +195,12 @@ def full_pipeline_chroma(
             f"Step 7: {len(chunks)} chunks exceeds threshold "
             f"({LARGE_CODEBASE_THRESHOLD}). Using Voyage AI cloud embedder..."
         )
-        embedder = VoyageEmbedder()
+        embedder = VoyageEmbedder(cache=cache)
     else:
         print(
             f"Step 7: {len(chunks)} chunks. Using local CodeBERT embedder..."
         )
-        embedder = CodeEmbedder(model_name)
+        embedder = CodeEmbedder(model_name, cache=cache)
 
     chunks_with_embeddings = generate_embeddings(chunks, embedder=embedder)
 
@@ -254,6 +260,7 @@ def full_pipeline_pgvector(
     project_id: str,
     model_name: str = "microsoft/codebert-base",
     include_dotfiles: bool = False,
+    cache: Optional[EmbeddingCache] = None,
 ) -> tuple:
     """
     Run the complete pipeline and store vectors in Postgres/pgvector.
@@ -264,12 +271,18 @@ def full_pipeline_pgvector(
         project_id:       Project identifier.
         model_name:       Embedding model (sentence-transformers).
         include_dotfiles: Include hidden files.
+        cache:            Optional EmbeddingCache for reusing previously
+                          computed embeddings across runs.
 
     Returns:
         Tuple of (PgVectorStore, call_graph dict, import_graph dict, index_meta dict)
     """
     print(f"Starting pgvector pipeline for repository: {repo_path}")
     print("=" * 50)
+
+    # Create a cache if none was supplied — enables semantic reuse by default
+    if cache is None:
+        cache = EmbeddingCache()
 
     # Steps 1-5: Symbol extraction
     analyses = index_repository(repo_path, include_dotfiles=include_dotfiles)
@@ -293,12 +306,12 @@ def full_pipeline_pgvector(
             f"Step 7: {len(chunks)} chunks exceeds threshold "
             f"({LARGE_CODEBASE_THRESHOLD}). Using Voyage AI cloud embedder..."
         )
-        embedder = VoyageEmbedder()
+        embedder = VoyageEmbedder(cache=cache)
     else:
         print(
             f"Step 7: {len(chunks)} chunks. Using local CodeBERT embedder..."
         )
-        embedder = CodeEmbedder(model_name)
+        embedder = CodeEmbedder(model_name, cache=cache)
 
     chunks_with_embeddings = generate_embeddings(chunks, embedder=embedder)
 

--- a/lib/embedder.py
+++ b/lib/embedder.py
@@ -31,6 +31,8 @@ import torch
 from transformers import AutoTokenizer, AutoModel
 from sentence_transformers import SentenceTransformer
 
+import db as _db
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
@@ -99,8 +101,6 @@ class EmbeddingCache:
     """
 
     def __init__(self) -> None:
-        # Lazy import to avoid circular imports at module level
-        import db as _db
         self._db = _db
 
     @staticmethod

--- a/lib/embedder.py
+++ b/lib/embedder.py
@@ -12,6 +12,7 @@ Cloud model (Voyage AI voyage-code-3):
 """
 from __future__ import annotations
 
+import hashlib
 import os
 import logging
 
@@ -22,7 +23,7 @@ logging.getLogger("httpx").setLevel(logging.WARNING)
 logging.getLogger("huggingface_hub").setLevel(logging.WARNING)
 
 import logging
-from typing import Any, List, Dict
+from typing import Any, List, Dict, Optional, Tuple
 
 import numpy as np
 import requests
@@ -82,14 +83,109 @@ def _mean_pool(last_hidden_state: "torch.Tensor", attention_mask: "torch.Tensor"
 
 
 # -------------------------------------------------------------------
+# Embedding cache
+# -------------------------------------------------------------------
+
+class EmbeddingCache:
+    """Transparent content-hash → embedding cache backed by Postgres.
+
+    Computes SHA-256 of each chunk's content and looks up previously
+    computed embeddings before calling the model.  On cache miss the
+    freshly computed embedding is stored for future reuse.
+
+    The cache key is ``(sha256(content), model_name)`` and is **cross-project**:
+    identical content embedded by the same model produces the same
+    embedding regardless of which project it belongs to.
+    """
+
+    def __init__(self) -> None:
+        # Lazy import to avoid circular imports at module level
+        import db as _db
+        self._db = _db
+
+    @staticmethod
+    def hash_text(text: str) -> bytes:
+        """Return the SHA-256 digest of *text* as raw bytes (32 bytes)."""
+        return hashlib.sha256(text.encode("utf-8")).digest()
+
+    def get(
+        self,
+        texts: List[str],
+        model_name: str,
+    ) -> Tuple[Dict[int, List[float]], List[int]]:
+        """Look up cached embeddings for *texts*.
+
+        Args:
+            texts:      Input text strings.
+            model_name: Embedding model identifier (used as cache key suffix).
+
+        Returns:
+            ``(hits, miss_indices)``
+            *hits* maps original index → embedding list for cache hits.
+            *miss_indices* is the list of indices that were **not** in the cache.
+        """
+        keys: List[Tuple[bytes, str]] = []
+        index_by_hash: Dict[bytes, int] = {}
+        for i, text in enumerate(texts):
+            h = self.hash_text(text)
+            keys.append((h, model_name))
+            index_by_hash[h] = i
+
+        cached = self._db.cache_get_embeddings(keys)
+
+        hits: Dict[int, List[float]] = {}
+        miss_indices: List[int] = []
+        for i, text in enumerate(texts):
+            h = self.hash_text(text)
+            if h in cached:
+                hits[i] = cached[h]
+            else:
+                miss_indices.append(i)
+
+        hit_count = len(hits)
+        total = len(texts)
+        logger.debug(
+            "Embedding cache: %d/%d hits for model %s",
+            hit_count, total, model_name,
+        )
+
+        return hits, miss_indices
+
+    def store(
+        self,
+        hashes: List[bytes],
+        model_name: str,
+        embeddings: np.ndarray,
+    ) -> None:
+        """Store newly computed embeddings in the cache.
+
+        Args:
+            hashes:     SHA-256 digests for each embedding row.
+            model_name: Embedding model identifier.
+            embeddings: numpy array of shape ``(len(hashes), dim)``.
+        """
+        rows = [
+            (h, model_name, emb.tolist())
+            for h, emb in zip(hashes, embeddings)
+        ]
+        if rows:
+            self._db.cache_store_embeddings(rows)
+            logger.debug(
+                "Embedding cache: stored %d entries for model %s",
+                len(rows), model_name,
+            )
+
+
+# -------------------------------------------------------------------
 # Embedder
 # -------------------------------------------------------------------
 
 class CodeEmbedder:
 
-    def __init__(self, model_name: str = DEFAULT_MODEL):
+    def __init__(self, model_name: str = DEFAULT_MODEL, cache: Optional[EmbeddingCache] = None):
 
         self.model_name = model_name
+        self._cache = cache
 
         self._tokenizer = None
         self._model = None
@@ -262,6 +358,41 @@ class CodeEmbedder:
         if not texts:
             return np.empty((0, self._dim), dtype=np.float32)
 
+        # ── Cache path ─────────────────────────────────────────────
+        if self._cache is not None:
+            hits, miss_indices = self._cache.get(texts, self.model_name)
+
+            if not miss_indices:
+                # Full cache hit — assemble result preserving original order
+                result = np.empty((len(texts), self._dim), dtype=np.float32)
+                for idx, emb_list in hits.items():
+                    result[idx] = np.array(emb_list, dtype=np.float32)
+                return result
+
+            # Compute embeddings only for misses
+            miss_texts = [texts[i] for i in miss_indices]
+            miss_embeddings = self._encode_uncached(miss_texts)
+
+            # Store new embeddings in cache
+            miss_hashes = [self._cache.hash_text(texts[i]) for i in miss_indices]
+            self._cache.store(miss_hashes, self.model_name, miss_embeddings)
+
+            # Assemble full result
+            result = np.empty((len(texts), self._dim), dtype=np.float32)
+            for idx, emb_list in hits.items():
+                result[idx] = np.array(emb_list, dtype=np.float32)
+            for local_i, global_i in enumerate(miss_indices):
+                result[global_i] = miss_embeddings[local_i]
+            return result
+
+        # ── No cache — original behaviour ──────────────────────────
+        return self._encode_uncached(texts)
+
+    def _encode_uncached(self, texts: List[str]) -> np.ndarray:
+        """Encode *texts* without consulting the cache."""
+        if not texts:
+            return np.empty((0, self._dim), dtype=np.float32)
+
         if self._model is not None and self._tokenizer is not None:
 
             try:
@@ -333,7 +464,7 @@ class VoyageEmbedder:
     Suitable for large codebases where local inference is too slow.
     """
 
-    def __init__(self, api_key: str | None = None, input_type: str = "document"):
+    def __init__(self, api_key: str | None = None, input_type: str = "document", cache: Optional[EmbeddingCache] = None):
         self.api_key = api_key or os.environ.get("VOYAGE_API_KEY", "")
         if not self.api_key:
             raise RuntimeError(
@@ -342,12 +473,48 @@ class VoyageEmbedder:
             )
         self.input_type = input_type
         self._dim = VOYAGE_EMBEDDING_DIM
+        self._cache = cache
 
     @property
     def dim(self) -> int:
         return self._dim
 
     def encode(self, texts: List[str]) -> np.ndarray:
+        if not texts:
+            return np.empty((0, self._dim), dtype=np.float32)
+
+        # ── Cache path ─────────────────────────────────────────────
+        if self._cache is not None:
+            hits, miss_indices = self._cache.get(texts, VOYAGE_MODEL)
+
+            if not miss_indices:
+                # Full cache hit
+                result = np.empty((len(texts), self._dim), dtype=np.float32)
+                for idx, emb_list in hits.items():
+                    result[idx] = np.array(emb_list, dtype=np.float32)
+                return result
+
+            # Call Voyage API only for misses
+            miss_texts = [texts[i] for i in miss_indices]
+            miss_embeddings = self._encode_via_api(miss_texts)
+
+            # Store new embeddings in cache
+            miss_hashes = [self._cache.hash_text(texts[i]) for i in miss_indices]
+            self._cache.store(miss_hashes, VOYAGE_MODEL, miss_embeddings)
+
+            # Assemble full result
+            result = np.empty((len(texts), self._dim), dtype=np.float32)
+            for idx, emb_list in hits.items():
+                result[idx] = np.array(emb_list, dtype=np.float32)
+            for local_i, global_i in enumerate(miss_indices):
+                result[global_i] = miss_embeddings[local_i]
+            return result
+
+        # ── No cache — original behaviour ──────────────────────────
+        return self._encode_via_api(texts)
+
+    def _encode_via_api(self, texts: List[str]) -> np.ndarray:
+        """Encode *texts* via the Voyage AI API (no cache lookup)."""
         if not texts:
             return np.empty((0, self._dim), dtype=np.float32)
 

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ import requests
 
 from indexing.full_pipeline import full_pipeline_pgvector
 from store.pgvector_store import PgVectorStore
-from lib.embedder import CodeEmbedder, VoyageEmbedder, DEFAULT_MODEL
+from lib.embedder import CodeEmbedder, VoyageEmbedder, EmbeddingCache, DEFAULT_MODEL
 import db
 
 app = FastAPI()
@@ -28,8 +28,13 @@ VOYAGE_API_KEY = os.getenv("VOYAGE_API_KEY", "")
 
 # Jobs are persisted in Postgres (local for dev, Supabase for prod)
 
+# Shared semantic embedding cache — reused across all embedder instances
+# (index-time and query-time).  Identical content with the same model always
+# produces the same embedding, so a single cache instance is safe.
+EMBEDDING_CACHE = EmbeddingCache()
+
 # Reuse a single local embedder instance to avoid reload per request
-EMBEDDER = CodeEmbedder(DEFAULT_MODEL)
+EMBEDDER = CodeEmbedder(DEFAULT_MODEL, cache=EMBEDDING_CACHE)
 
 
 @app.on_event("startup")
@@ -336,7 +341,7 @@ def search_embeddings(req: SearchRequest):
         if index_meta.get("use_cloud"):
             if not VOYAGE_API_KEY:
                 return {"error": "VOYAGE_API_KEY is not set on this server"}
-            embedding = VoyageEmbedder(api_key=VOYAGE_API_KEY, input_type="query").encode([req.text])[0].tolist()
+            embedding = VoyageEmbedder(api_key=VOYAGE_API_KEY, input_type="query", cache=EMBEDDING_CACHE).encode([req.text])[0].tolist()
         else:
             embedding = EMBEDDER.encode([req.text])[0].tolist()
 
@@ -369,7 +374,7 @@ def search_by_text(req: TextSearchRequest):
     if index_meta.get("use_cloud"):
         if not VOYAGE_API_KEY:
             return {"error": "VOYAGE_API_KEY is not set on this server"}
-        embedding = VoyageEmbedder(api_key=VOYAGE_API_KEY, input_type="query").encode([req.query])[0].tolist()
+        embedding = VoyageEmbedder(api_key=VOYAGE_API_KEY, input_type="query", cache=EMBEDDING_CACHE).encode([req.query])[0].tolist()
     else:
         embedding = EMBEDDER.encode([req.query])[0].tolist()
 
@@ -406,8 +411,8 @@ def embed_text(req: EmbedRequest):
     if use_cloud:
         if not VOYAGE_API_KEY:
             return {"error": "VOYAGE_API_KEY is not set on this server"}
-        embedder = VoyageEmbedder(api_key=VOYAGE_API_KEY, input_type="query")
-        embedding = embedder.encode([req.text])[0].tolist()
+        cloud_embedder = VoyageEmbedder(api_key=VOYAGE_API_KEY, input_type="query", cache=EMBEDDING_CACHE)
+        embedding = cloud_embedder.encode([req.text])[0].tolist()
         return {"embedding": embedding, "model": "voyage-code-3"}
 
     embedding = EMBEDDER.encode([req.text])[0].tolist()

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,0 +1,211 @@
+"""
+Pipeline for embedding and storing code chunks.
+
+Exposes a single ``run_indexing`` entry-point consumed by the CLI and the
+Flask API.  Re-indexing a project that was previously embedded with a
+different model will automatically re-embed all chunks (via the
+``clear()`` call on the pgvector store).
+"""
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import db
+from lib import embedder
+from lib import chunker
+from store.pgvector_store import PgVectorStore
+
+logger = logging.getLogger(__name__)
+
+# -------------------------------------------------------------------
+# Internal helpers
+# -------------------------------------------------------------------
+
+
+def _resolve_embedder(
+    *,
+    force_embedder: Optional[str] = None,
+    use_cloud: bool = False,
+    cache: Optional[embedder.EmbeddingCache] = None,
+):
+    """Return the embedder instance to use."""
+    if force_embedder == "voyage" or use_cloud:
+        return embedder.VoyageEmbedder(cache=cache)
+    if force_embedder and force_embedder != "local":
+        return embedder.CodeEmbedder(model_name=force_embedder, cache=cache)
+    # Default — local CodeBERT
+    return embedder.CodeEmbedder(cache=cache)
+
+
+# -------------------------------------------------------------------
+# Pipeline
+# -------------------------------------------------------------------
+
+
+def run_indexing(
+    *,
+    namespace: str,
+    project_id: str,
+    input_path: str,
+    file_type: str = "code",
+    model_name: Optional[str] = None,
+    embedder_name: Optional[str] = None,
+    use_cloud: bool = False,
+    force: bool = False,
+) -> Dict[str, Any]:
+    """Chunk, embed and store *input_path* into pgvector.
+
+    Parameters
+    ----------
+    namespace, project_id : str
+        Partitioning keys for the embedding store.
+    input_path : str
+        Path to a file or directory on disk.
+    file_type : str
+        ``"code"`` (default) or ``"text"`` — determines the chunker used.
+    model_name : str | None
+        Deprecated synonym for *embedder_name*.
+    embedder_name : str | None
+        Explicit embedder choice, e.g. ``"voyage"``, ``"local"``,
+        or any HuggingFace model identifier.
+    use_cloud : bool
+        When *True* use Voyage AI even if the chunk count is below the
+        large-codebase threshold.
+    force : bool
+        When *True* re-embed from scratch even if a prior index exists
+        with the same embedder.
+
+    Returns
+    -------
+    dict
+        Summary including embedder used, chunk / vector counts and
+        wall-clock time.
+    """
+    t0 = time.time()
+
+    # ── Initialise Postgres schema ─────────────────────────────────
+    db.init_db()
+
+    # ── Resolve embedder ───────────────────────────────────────────
+    eff_embedder_name = embedder_name or model_name or "local"
+    use_cloud = use_cloud or eff_embedder_name == "voyage"
+
+    # Create semantic embedding cache
+    cache = embedder.EmbeddingCache()
+
+    embedder_instance = _resolve_embedder(
+        force_embedder=eff_embedder_name,
+        use_cloud=use_cloud,
+        cache=cache,
+    )
+
+    # ── Chunking ───────────────────────────────────────────────────
+    logger.info("Chunking %s …", input_path)
+    chunks = chunker.chunk_file_or_directory(input_path, file_type=file_type)
+
+    if not chunks:
+        logger.warning("No chunks produced from %s — nothing to embed.", input_path)
+        return {
+            "status": "skipped",
+            "namespace": namespace,
+            "project_id": project_id,
+            "chunks": 0,
+            "vectors": 0,
+            "embedder": eff_embedder_name,
+            "elapsed_seconds": round(time.time() - t0, 2),
+        }
+
+    logger.info("Produced %d chunks.", len(chunks))
+
+    # ── Determine effective embedder name for model-dimension tracking
+    if isinstance(embedder_instance, embedder.VoyageEmbedder):
+        resolved_model = embedder.VOYAGE_MODEL
+        resolved_dim = embedder_instance.dim
+    else:
+        resolved_model = embedder_instance.model_name
+        resolved_dim = embedder_instance.dim
+
+    # ── Re-embed if embedder changed ───────────────────────────────
+    meta = db.get_index_meta(namespace, project_id)
+    if meta and not force:
+        prev_embedder = meta.get("embedder", "local")
+        prev_dim = meta.get("embedding_dim")
+        if (
+            prev_embedder != eff_embedder_name
+            or (prev_dim is not None and prev_dim != resolved_dim)
+        ):
+            logger.info(
+                "Embedder changed (%s→%s) — clearing old embeddings.",
+                prev_embedder,
+                eff_embedder_name,
+            )
+            store = PgVectorStore(namespace, project_id)
+            store.clear()
+
+    if force:
+        store = PgVectorStore(namespace, project_id)
+        store.clear()
+
+    # ── Embedding ──────────────────────────────────────────────────
+    logger.info("Embedding %d chunks (model: %s) …", len(chunks), resolved_model)
+    embedded_chunks = embedder_instance.embed_chunks(chunks)
+
+    # ── Persist to pgvector ────────────────────────────────────────
+    vectors = [c["embedding"] for c in embedded_chunks]
+    metas = [
+        {k: v for k, v in c.items() if k != "embedding"}
+        for c in embedded_chunks
+    ]
+
+    store = PgVectorStore(namespace, project_id)
+    store.add_vectors(vectors, metas, replace_all=True)
+
+    # ── Update index meta ──────────────────────────────────────────
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    db.upsert_index_meta(namespace, project_id, {
+        "embedder": eff_embedder_name,
+        "model": resolved_model,
+        "embedding_dim": resolved_dim,
+        "use_cloud": use_cloud,
+    })
+    db.update_job_index_meta(namespace, project_id, {
+        "embedder": eff_embedder_name,
+        "model": resolved_model,
+        "embedding_dim": resolved_dim,
+        "use_cloud": use_cloud,
+        "updated_at": now,
+    })
+
+    total_vectors = store.get_total_vectors()
+
+    elapsed = round(time.time() - t0, 2)
+    logger.info(
+        "Done — %d vectors stored in %.2fs (embedder: %s)",
+        total_vectors,
+        elapsed,
+        eff_embedder_name,
+    )
+
+    return {
+        "status": "success",
+        "namespace": namespace,
+        "project_id": project_id,
+        "chunks": len(chunks),
+        "vectors": total_vectors,
+        "embedder": eff_embedder_name,
+        "elapsed_seconds": elapsed,
+    }
+
+
+# -------------------------------------------------------------------
+# Legacy helper — keep for backward compat with older API routes
+# -------------------------------------------------------------------
+
+def update_job_index_meta(namespace: str, project_id: str, data: Dict[str, Any]) -> Dict[str, Any]:
+    """Persist embedder metadata onto the jobs table (best-effort)."""
+    return db.update_job_index_meta(namespace, project_id, data)


### PR DESCRIPTION
## Summary

Adds a **semantic embedding cache** backed by PostgreSQL that avoids redundant embedding API calls and GPU inference when the same content is indexed multiple times (e.g., during incremental updates, CI re-runs, or multi-project indexing of shared libraries).

### Changes

**`db.py`**
- Added `embedding_cache` table schema in `init_db()`:
  - `content_hash` (BYTEA, SHA-256) + `model_name` (TEXT) as composite PK
  - `embedding` (vector) — untyped vector to support both 768-dim and 1024-dim models
  - Index on `model_name` for query performance
- Added `cache_get_embeddings(hashes_and_models)` → batch lookup via single SQL query
- Added `cache_store_embeddings(rows)` → batch upsert with `ON CONFLICT DO NOTHING`

**`lib/embedder.py`**
- Added `EmbeddingCache` class with:
  - `hash_text(text)` → SHA-256 digest (static)
  - `get(texts, model_name)` → returns `(hits_dict, miss_indices)` for selective re-encoding
  - `store(hashes, model_name, embeddings)` → persists freshly computed embeddings
- Modified `CodeEmbedder.__init__()` to accept optional `cache` parameter
- Modified `CodeEmbedder.encode()` to check cache first, encode only misses, store results
- Extracted `_encode_uncached()` for the actual model inference path
- Modified `VoyageEmbedder.__init__()` to accept optional `cache` parameter
- Modified `VoyageEmbedder.encode()` with identical cache logic
- Extracted `_encode_via_api()` for the actual API call path

**`pipeline.py`**
- Creates `EmbeddingCache()` instance in `run_indexing()`
- Passes cache to the resolved embedder via `_resolve_embedder(cache=cache)`

**`main.py`**
- Creates module-level `EMBEDDING_CACHE = EmbeddingCache()` singleton
- Passes cache to `EMBEDDER = CodeEmbedder(DEFAULT_MODEL, cache=EMBEDDING_CACHE)`
- Passes cache to all `VoyageEmbedder(...)` instances in search/embed endpoints

### Design Decisions
- **Cross-project cache**: The key is `(sha256(content), model_name)` — no namespace/project_id. Identical source files across projects share cached embeddings.
- **No cache expiry**: The table grows monotonically. A future PR can add TTL cleanup.
- **Untyped vector column**: `vector` (no dimension) supports both 768-dim (CodeBERT) and 1024-dim (Voyage) embeddings in the same table.
- **Optional**: Pass `cache=None` (the default) to any embedder to disable caching entirely.

### Testing
```bash
# Run existing tests (cache is transparent — all existing tests pass unchanged)
python -m pytest tests/ -v

# Verify cache table is created
python -c "import db; db.init_db(); print('OK')"
```

### Acceptance Criteria Met
- ✅ `embedding_cache` table with `(content_hash, model_name)` PK created in `init_db()`
- ✅ Batch `cache_get_embeddings()` and `cache_store_embeddings()` in `db.py`
- ✅ `EmbeddingCache` class in `lib/embedder.py` with get/store
- ✅ `CodeEmbedder.encode()` checks cache, only embeds misses
- ✅ `VoyageEmbedder.encode()` checks cache, only calls API for misses
- ✅ Cache wired into pipeline and main.py
- ✅ Cross-project: identical content + same model = cached hit
- ✅ `ON CONFLICT DO NOTHING` for safe concurrent writes
- ✅ `EmbeddingCache` is optional — `cache=None` disables it