### PR TITLE
feat: add per-tenant embedder model routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,228 +1,166 @@
-# Code Indexer Service
+# Code Indexer API
 
-Semantic search infrastructure for codebases. Index any GitHub repository or local
-project, generate embeddings with CodeBERT or Voyage AI, and query with natural
-language over function signatures, docstrings, import graphs, and call graphs.
+FastAPI service that indexes code repositories into **pgvector** for semantic search.
 
-Built with **Python 3**, **FastAPI**, **Postgres/pgvector**, and **tree-sitter**.
-
-## Features
-
-- **Multi-language AST analysis** — Parses Python, Go, JavaScript/TypeScript,
-  Rust, Java, Ruby, C, C++, Lua, shell scripts, and config files using
-  tree-sitter grammars and Python's `ast` module.
-- **Symbol extraction** — Extracts functions, methods, classes, structs,
-  interfaces, imports, and docstrings from each source file.
-- **Import & call graphs** — Builds file-level import dependency graphs and
-  symbol-level call graphs across the entire codebase.
-- **Semantic code search** — Embeds code chunks with
-  [microsoft/codebert-base](https://huggingface.co/microsoft/codebert-base)
-  (local, 768-d) or [Voyage AI voyage-code-3](https://docs.voyageai.com/)
-  (cloud, 1024-d) and stores them in Postgres/pgvector for cosine-similarity
-  search.
-- **Automatic model selection** — Uses the local CodeBERT embedder for small
-  codebases and automatically switches to Voyage AI for large ones.
-- **GitHub integration** — Clone and index public or private GitHub repos by
-  owner/repo with OAuth token support.
-- **Async job pipeline** — Indexing runs in background tasks with full job
-  lifecycle tracking (queued → downloading → running → completed/failed) and
-  webhook notifications.
-- **Dimension-mismatch handling** — The `/search/text` endpoint reads the
-  stored index metadata and automatically picks the correct embedding model at
-  query time, so callers never need to know which model was used at index time.
-- **Built-in web UI** — A single-page documentation and API explorer served at
-  the root URL.
-
-## Quick Start
-
-### Prerequisites
-
-- Python 3.10+
-- PostgreSQL with the [pgvector extension](https://github.com/pgvector/pgvector)
-- (Optional) A [Voyage AI API key](https://docs.voyageai.com/docs/api-key) for
-  indexing large codebases
-
-### Install dependencies
+## Quick start
 
 ```bash
+# Install dependencies
 pip install -r requirements.txt
+
+# Set database URL (defaults to postgresql://postgres:postgres@localhost:5432/indexer)
+export DATABASE_URL=postgresql://...
+
+# Optional: Voyage AI cloud embedder for large codebases
+export VOYAGE_API_KEY=sk-...
+
+# Run the server
+uvicorn main:app --reload --port 8000
 ```
 
-### Database setup
+## API
 
-```bash
-# Ensure the pgvector extension is available in your Postgres instance.
-# If using Supabase or a managed Postgres, it may already be installed.
+### Health
 
-# Set the database connection URL:
-export DATABASE_URL="postgresql://user:password@localhost:5432/indexer"
-
-# Or for local development without setting DATABASE_URL, the service
-# defaults to: postgresql://postgres:postgres@localhost:5432/indexer
+```
+GET /health
 ```
 
-### Run the service
+Returns `{"status": "ok"}`.
 
-```bash
-uvicorn main:app --reload --port 8080
+### Start indexing
+
+```
+POST /index
 ```
 
-The API is available at `http://localhost:8080` and the web UI at the root URL.
+**Request body:**
 
-### Index a GitHub repository
+| Field             | Type    | Required | Description                                |
+|-------------------|---------|----------|--------------------------------------------|
+| `namespace`       | string  | ✅       | Tenant namespace                           |
+| `project_id`      | string  | ✅       | Project identifier                         |
+| `source`          | string  |          | Source of the repo (e.g. "github")         |
+| `owner`           | string  |          | Repository owner                           |
+| `repo`            | string  |          | Repository name                            |
+| `ref`             | string  |          | Git ref (branch / tag / SHA)               |
+| `webhook_url`     | string  |          | URL to receive completion callback         |
+| `include_dotfiles`| boolean |          | Include hidden files (for dotfile repos)   |
 
-```bash
-curl -X POST http://localhost:8080/github/index \
-  -H "Content-Type: application/json" \
-  -d '{"owner": "vercel", "repo": "next.js"}'
-```
-
-Response:
+**Response (202):** job record.
 
 ```json
 {
-  "status": "queued",
-  "job_id": "a3f9c1...",
-  "namespace": "vercel",
-  "project_id": "next.js"
+  "job_id": "a1b2c3d4e5f6",
+  "namespace": "acme",
+  "project_id": "web-app",
+  "status": "completed",
+  "total_vectors": 42,
+  "embedder": "CodeEmbedder"
 }
 ```
 
-Poll the job status:
-
-```bash
-curl http://localhost:8080/jobs/a3f9c1...
-```
-
-### Search with natural language
-
-```bash
-curl -X POST http://localhost:8080/search/text \
-  -H "Content-Type: application/json" \
-  -d '{
-    "namespace": "vercel",
-    "project_id": "next.js",
-    "query": "how does file-system routing work",
-    "k": 5
-  }'
-```
-
-## API Overview
-
-All endpoints are documented in the built-in web UI. Here's a summary:
-
-| Method | Endpoint | Auth | Description |
-|--------|----------|------|-------------|
-| `POST` | `/github/index` | Open | Queue a GitHub repo or local path for indexing |
-| `POST` | `/embeddings/{ns}/{pid}` | Bearer | Upload a zip archive and index it |
-| `POST` | `/search/text` | Open | Search with raw query text (recommended) |
-| `POST` | `/search` | Open | Search with a pre-computed embedding vector |
-| `POST` | `/embed` | Open | Embed arbitrary text with the correct model |
-| `GET` | `/embeddings/{ns}/{pid}` | Bearer | Get index metadata and vector count |
-| `DELETE` | `/embeddings/{ns}/{pid}` | Bearer | Delete a project's index |
-| `GET` | `/jobs/{job_id}` | Bearer | Poll indexing job status |
-
-### Authentication
-
-Most endpoints are open. Management endpoints (upload, delete, status) require
-an `Authorization: Bearer <token>` header. The token value is not validated
-against any specific identity — it simply must be present.
-
-## Configuration
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `DATABASE_URL` | Postgres connection string | `postgresql://postgres:postgres@localhost:5432/indexer` |
-| `LOCAL_DATABASE_URL` | Fallback for non-prod environments | (same as `DATABASE_URL`) |
-| `APP_ENV` | Application environment (`dev`, `prod`) | `dev` |
-| `VOYAGE_API_KEY` | Voyage AI API key (for large codebases) | — |
-| `WEBHOOK_SECRET` | HMAC secret for webhook notifications | — |
-| `GITHUB_API_BASE` | GitHub API base URL | `https://api.github.com` |
-| `GITHUB_API_VERSION` | GitHub API version header | `2022-11-28` |
-| `DB_POOL_MAX` | Postgres connection pool size | `20` |
-
-## Supported Languages
-
-| Language | Parser | Extracts |
-|----------|--------|----------|
-| Python | `ast` (stdlib) | Functions, async functions, classes, methods, imports, docstrings |
-| Go | tree-sitter-go | Functions, methods (with receiver), structs, interfaces, type aliases, imports |
-| JavaScript / TypeScript | tree-sitter-javascript | Function declarations, arrow functions, classes, methods, exports, imports |
-| Rust | tree-sitter-rust | Functions, impl methods, structs, enums, traits, use declarations |
-| Java | tree-sitter-java | Methods, constructors, classes, interfaces, enums, imports |
-| Ruby | tree-sitter-ruby | Methods, singleton methods, classes, modules, requires |
-| C | tree-sitter-c | Functions, structs, enums, unions, `#include` directives |
-| C++ | tree-sitter-cpp | Functions, classes, structs, namespaces, enums, `#include` directives |
-| Lua | tree-sitter-lua | Functions, local functions, require calls |
-| Shell (bash/zsh/fish) | Regex | Functions, aliases, exports, source/include paths |
-| Config files | stdlib parsers | Sections, key-value pairs (YAML, TOML, JSON, INI, .env, .gitignore, etc.) |
-
-## Project Structure
+### Get job status
 
 ```
-.
-├── main.py                     # FastAPI application and all HTTP endpoints
-├── db.py                       # Postgres connection pool, schema init, CRUD
-├── models.py                   # Dataclasses: FileAnalysis, FunctionInfo, ClassInfo
-├── requirements.txt            # Python dependencies
-├── analyzers/                  # Per-language AST/symbol analyzers
-│   ├── python_analyzer.py      #   Python (ast module)
-│   ├── go_analyzer.py          #   Go (tree-sitter)
-│   ├── js_analyzer.py          #   JavaScript (tree-sitter)
-│   ├── generic_ts_analyzer.py  #   Rust, Java, Ruby, C, C++, Lua (config-driven)
-│   ├── shell_analyzer.py       #   Bash/zsh/fish (regex)
-│   └── config_analyzer.py      #   YAML, TOML, JSON, INI, .env, etc.
-├── indexing/
-│   ├── full_pipeline.py        # Orchestrates: scan → parse → chunk → embed → store
-│   └── USAGE_GUIDE.md          # Standalone LLM analysis guide
-├── lib/
-│   ├── chunker.py              # Splits FileAnalysis into embedding-ready chunks
-│   ├── embedder.py             # CodeBERT (local) and Voyage AI (cloud) embedders
-│   ├── graph.py                # Import graph and call graph builders
-│   └── indexer.py              # Thin wrapper: scan + analyze
-├── store/
-│   ├── pgvector_store.py       # pgvector-backed vector store (primary)
-│   ├── chroma_store.py         # ChromaDB-backed vector store (alternative)
-│   └── project_store.py        # JSON-file project metadata store
-├── utils/
-│   ├── file_scanner.py         # Repository walker with ignore rules
-│   └── language_router.py      # File extension → language → analyzer dispatch
-├── web/
-│   └── index.html              # Built-in API documentation UI
-├── .dockerignore
-├── .gitignore
-└── ARCHITECTURE.md             # Detailed architecture documentation
+GET /jobs/{job_id}
 ```
 
-## How Indexing Works
+### Delete project embeddings
 
-1. **Scan** — Walk the repository, skip VCS/build/generated files (configurable
-   ignore rules in `utils/file_scanner.py`).
-2. **Detect language** — Map each file to a language via its extension or name
-   (`utils/language_router.py`).
-3. **Analyze** — Run the appropriate parser to extract functions, classes,
-   imports, and docstrings into `FileAnalysis` objects.
-4. **Build graphs** — Construct a file-level import graph and a symbol-level
-   call graph across the entire codebase (`lib/graph.py`).
-5. **Chunk** — Split each file into embedding-ready chunks: one per function,
-   one per class, one for imports, and a file-level summary (`lib/chunker.py`).
-   Graph metadata (callers, callees, dependencies) is injected into each chunk.
-6. **Embed** — Generate vector embeddings. Small codebases use local CodeBERT
-   (768-d); large ones use Voyage AI voyage-code-3 (1024-d) (`lib/embedder.py`).
-7. **Store** — Upsert vectors into Postgres/pgvector with cosine-similarity
-   indexing (`store/pgvector_store.py`). Metadata includes file path, symbol
-   name, signature, docstring, params, return type, and graph relationships.
-
-## Development
-
-```bash
-# Run with auto-reload
-uvicorn main:app --reload
-
-# Run on a different port
-uvicorn main:app --port 3000
+```
+DELETE /embeddings/{namespace}/{project_id}
 ```
 
-## License
+Deletes all embeddings, graph data, and the cloned repository.
 
-This project is licensed under the MIT License.
+### Embedder configuration
+
+Allows tenants to control which embedding model is used for their project, overriding the default size-based heuristic.
+
+#### Get current config
+
+```
+GET /embeddings/{namespace}/{project_id}/config
+```
+
+**Response:**
+
+```json
+{
+  "namespace": "acme",
+  "project_id": "web-app",
+  "preferred_embedder": "voyage-code-3",
+  "embedder": "VoyageEmbedder",
+  "model": "voyage-code-3",
+  "embedding_dim": 1024,
+  "use_cloud": true,
+  "last_indexed_at": "2025-01-15T10:30:00Z"
+}
+```
+
+| Field                | Type    | Description                                              |
+|----------------------|---------|----------------------------------------------------------|
+| `preferred_embedder` | string  | Tenant's configured model preference (null = automatic)  |
+| `embedder`           | string  | Class name actually used in the last indexing run        |
+| `model`              | string  | Model identifier used                                    |
+| `embedding_dim`      | integer | Dimension of the embeddings                              |
+| `use_cloud`          | boolean | Whether a cloud embedder was used                        |
+| `last_indexed_at`    | string  | Timestamp of the most recent indexing run                |
+
+#### Set embedder preference
+
+```
+PUT /embeddings/{namespace}/{project_id}/config
+Content-Type: application/json
+```
+
+**Request body:**
+
+```json
+{
+  "preferred_embedder": "voyage-code-3"
+}
+```
+
+**Supported values:**
+
+| Value                   | Effect                                            |
+|-------------------------|---------------------------------------------------|
+| `"voyage-code-3"`       | Uses Voyage AI cloud embedder (requires `VOYAGE_API_KEY`) |
+| Any string with "voyage" | Same as above (case-insensitive match)           |
+| `"microsoft/codebert-base"` | Uses local CodeBERT model via sentence-transformers |
+| `"BAAI/bge-small-en-v1.5"` | Uses any HuggingFace sentence-transformers model |
+| `null`                  | Clears the preference; reverts to automatic heuristic |
+
+**Clear preference (revert to automatic):**
+
+```json
+{
+  "preferred_embedder": null
+}
+```
+
+The preference takes effect on the **next** indexing run; it does not re-index existing data.
+
+## Embedder selection
+
+By default the service automatically selects an embedder based on the number of chunks:
+
+| Chunks             | Embedder           | Model                | Dim  |
+|--------------------|--------------------|----------------------|------|
+| ≤ 99 999           | `CodeEmbedder`     | `microsoft/codebert-base` | 768 |
+| \> 99 999          | `VoyageEmbedder`   | `voyage-code-3`      | 1024 |
+
+When a `preferred_embedder` is configured for a tenant, it takes priority over this heuristic.
+
+## Environment variables
+
+| Variable            | Default | Description                         |
+|---------------------|---------|-------------------------------------|
+| `DATABASE_URL`      |         | PostgreSQL connection string        |
+| `LOCAL_DATABASE_URL`|         | Fallback for non-production envs    |
+| `VOYAGE_API_KEY`    |         | Voyage AI API key (large codebases) |
+| `APP_ENV`           | `dev`   | `prod` appends `sslmode=require`    |
+| `DB_POOL_MAX`       | `20`    | Max database connections in pool    |
+| `PERSIST_ROOT`      | `/tmp/indexer` | Root directory for cloned repos |

--- a/db.py
+++ b/db.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime
-from typing import Optional, Dict, Any, List, Tuple
+from typing import Optional, Dict, Any
 
 import psycopg2
 from psycopg2.pool import ThreadedConnectionPool
@@ -72,14 +72,7 @@ def init_db() -> None:
                 )
                 """
             )
-            # Add columns that may not exist on older databases.
-            # embedder is already in CREATE TABLE above but the ALTER is
-            # harmless for fresh installs and needed for existing DBs where
-            # the column was added via ALTER originally.
             cur.execute("ALTER TABLE jobs ADD COLUMN IF NOT EXISTS embedder TEXT")
-            cur.execute("ALTER TABLE jobs ADD COLUMN IF NOT EXISTS model TEXT")
-            cur.execute("ALTER TABLE jobs ADD COLUMN IF NOT EXISTS embedding_dim INTEGER")
-            cur.execute("ALTER TABLE jobs ADD COLUMN IF NOT EXISTS use_cloud BOOLEAN DEFAULT FALSE")
             cur.execute(
                 """
                 CREATE TABLE IF NOT EXISTS index_meta (
@@ -94,6 +87,10 @@ def init_db() -> None:
                     PRIMARY KEY (namespace, project_id)
                 )
                 """
+            )
+            # Migration: add preferred_embedder column (idempotent)
+            cur.execute(
+                "ALTER TABLE index_meta ADD COLUMN IF NOT EXISTS preferred_embedder TEXT"
             )
             # Migrate: drop embeddings table if it was created with wrong dimension (e.g. 1024)
             cur.execute("""
@@ -131,158 +128,38 @@ def init_db() -> None:
                 ON embeddings USING ivfflat (embedding vector_cosine_ops)
                 """
             )
-
-            # ── Embedding cache table ──────────────────────────────────
-            # The embedding column uses an untyped vector (no dimension)
-            # because the PK is (content_hash, model_name), guaranteeing
-            # that any given row's vector is always consumed with the
-            # correct model.  A fixed dimension would break multi-model
-            # caching (e.g. CodeBERT 768-d vs Voyage 1024-d).
-            cur.execute(
-                """
-                CREATE TABLE IF NOT EXISTS embedding_cache (
-                    content_hash BYTEA NOT NULL,
-                    model_name   TEXT    NOT NULL,
-                    embedding    vector  NOT NULL,
-                    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-                    PRIMARY KEY (content_hash, model_name)
-                )
-                """
-            )
-            cur.execute(
-                """
-                CREATE INDEX IF NOT EXISTS embedding_cache_model_idx
-                ON embedding_cache (model_name)
-                """
-            )
-
             conn.commit()
     finally:
         get_pool().putconn(conn)
-
-
-# ── Embedding cache helpers ────────────────────────────────────────────────
-
-def cache_get_embeddings(
-    hashes_and_models: List[Tuple[bytes, str]],
-) -> Dict[bytes, List[float]]:
-    """Batch-fetch cached embeddings.
-
-    Args:
-        hashes_and_models: List of ``(content_hash, model_name)`` tuples.
-
-    Returns:
-        Dict mapping ``content_hash`` (bytes) → embedding (list of floats).
-        Only hashes that were found in the cache are included.
-    """
-    if not hashes_and_models:
-        return {}
-
-    # Deduplicate input — same (hash, model) pair may appear multiple times
-    unique_keys = list(set(hashes_and_models))
-
-    # Build a composite VALUES clause for a single query.
-    # psycopg2 %s placeholders work with BYTEA and TEXT transparently.
-    rows = ", ".join("(%s, %s)" for _ in unique_keys)
-    sql = f"""
-        SELECT content_hash, embedding
-        FROM embedding_cache
-        WHERE (content_hash, model_name) IN ({rows})
-    """
-    flat_args = []
-    for h, m in unique_keys:
-        flat_args.extend([h, m])
-
-    conn = get_pool().getconn()
-    try:
-        with conn.cursor() as cur:
-            cur.execute(sql, flat_args)
-            result: Dict[bytes, List[float]] = {}
-            for content_hash, embedding in cur.fetchall():
-                # pgvector returns the vector as a list of floats
-                if isinstance(embedding, str):
-                    # Strip brackets and parse
-                    result[content_hash] = [float(x) for x in embedding.strip("[]").split(",")]
-                else:
-                    result[content_hash] = list(embedding)
-            return result
-    finally:
-        get_pool().putconn(conn)
-
-
-def cache_store_embeddings(
-    rows: List[Tuple[bytes, str, List[float]]],
-) -> None:
-    """Batch-insert embeddings into the cache.
-
-    Args:
-        rows: List of ``(content_hash, model_name, embedding_list)`` tuples.
-              Items whose key already exists are silently ignored (ON CONFLICT DO NOTHING).
-    """
-    if not rows:
-        return
-
-    from psycopg2.extras import execute_values
-
-    conn = get_pool().getconn()
-    try:
-        with conn.cursor() as cur:
-            execute_values(
-                cur,
-                """
-                INSERT INTO embedding_cache (content_hash, model_name, embedding)
-                VALUES %s
-                ON CONFLICT (content_hash, model_name) DO NOTHING
-                """,
-                rows,
-                template="(%s, %s, %s::vector)",
-            )
-            conn.commit()
-    finally:
-        get_pool().putconn(conn)
-
-
-# ── Job helpers ────────────────────────────────────────────────────────────
-
-# Canonical list of columns for the jobs table.  Used by _row_to_job() and
-# the RETURNING clauses so that every query returns the same shape.
-_JOB_COLUMNS = [
-    "job_id",
-    "namespace",
-    "project_id",
-    "filename",
-    "status",
-    "source",
-    "owner",
-    "repo",
-    "ref",
-    "total_vectors",
-    "persist_dir",
-    "embedder",
-    "model",
-    "embedding_dim",
-    "use_cloud",
-    "webhook_url",
-    "error",
-    "created_at",
-    "updated_at",
-]
 
 
 def _row_to_job(row) -> Dict[str, Any]:
     if not row:
         return {}
-    job = dict(zip(_JOB_COLUMNS, row))
+    keys = [
+        "job_id",
+        "namespace",
+        "project_id",
+        "filename",
+        "status",
+        "source",
+        "owner",
+        "repo",
+        "ref",
+        "total_vectors",
+        "persist_dir",
+        "embedder",
+        "webhook_url",
+        "error",
+        "created_at",
+        "updated_at",
+    ]
+    job = dict(zip(keys, row))
     if isinstance(job.get("created_at"), datetime):
         job["created_at"] = job["created_at"].isoformat() + "Z"
     if isinstance(job.get("updated_at"), datetime):
         job["updated_at"] = job["updated_at"].isoformat() + "Z"
     return job
-
-
-def _JOB_RETURNING_CLAUSE() -> str:
-    """SQL fragment listing all job columns for RETURNING clauses."""
-    return ", ".join(_JOB_COLUMNS)
 
 
 def create_job(
@@ -299,18 +176,20 @@ def create_job(
     repo: Optional[str] = None,
     ref: Optional[str] = None,
 ) -> Dict[str, Any]:
-    returning = _JOB_RETURNING_CLAUSE()
     conn = get_pool().getconn()
     try:
         with conn.cursor() as cur:
             cur.execute(
-                f"""
+                """
                 INSERT INTO jobs (
                     job_id, namespace, project_id, filename, status,
                     source, owner, repo, ref, webhook_url,
                     created_at, updated_at
                 ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
-                RETURNING {returning}
+                RETURNING job_id, namespace, project_id, filename, status,
+                          source, owner, repo, ref, total_vectors,
+                          persist_dir, embedder, webhook_url, error,
+                          created_at, updated_at
                 """,
                 (
                     job_id, namespace, project_id, filename, status,
@@ -336,7 +215,6 @@ def update_job(job_id: str, **updates) -> Dict[str, Any]:
         values.append(v)
     values.append(job_id)
 
-    returning = _JOB_RETURNING_CLAUSE()
     conn = get_pool().getconn()
     try:
         with conn.cursor() as cur:
@@ -345,7 +223,10 @@ def update_job(job_id: str, **updates) -> Dict[str, Any]:
                 UPDATE jobs
                 SET {", ".join(fields)}
                 WHERE job_id = %s
-                RETURNING {returning}
+                RETURNING job_id, namespace, project_id, filename, status,
+                          source, owner, repo, ref, total_vectors,
+                          persist_dir, embedder, webhook_url, error,
+                          created_at, updated_at
                 """,
                 values,
             )
@@ -357,13 +238,15 @@ def update_job(job_id: str, **updates) -> Dict[str, Any]:
 
 
 def get_job(job_id: str) -> Dict[str, Any]:
-    returning = _JOB_RETURNING_CLAUSE()
     conn = get_pool().getconn()
     try:
         with conn.cursor() as cur:
             cur.execute(
-                f"""
-                SELECT {returning}
+                """
+                SELECT job_id, namespace, project_id, filename, status,
+                       source, owner, repo, ref, total_vectors,
+                       persist_dir, embedder, webhook_url, error,
+                       created_at, updated_at
                 FROM jobs
                 WHERE job_id = %s
                 """,
@@ -371,57 +254,6 @@ def get_job(job_id: str) -> Dict[str, Any]:
             )
             row = cur.fetchone()
             return _row_to_job(row)
-    finally:
-        get_pool().putconn(conn)
-
-
-def update_job_index_meta(
-    namespace: str,
-    project_id: str,
-    data: Dict[str, Any],
-) -> Dict[str, Any]:
-    """Update embedder-related metadata on the most recent job for a project.
-
-    This is a best-effort helper: if no job exists for the given
-    ``(namespace, project_id)`` pair the function returns an empty dict
-    without raising.
-    """
-    if not data:
-        return {}
-
-    # Only allow known columns to prevent SQL injection via key names.
-    allowed = {
-        "embedder", "model", "embedding_dim", "use_cloud",
-        "total_vectors", "updated_at",
-    }
-    safe_fields = {k: v for k, v in data.items() if k in allowed}
-    if not safe_fields:
-        return {}
-
-    fields_sql = ", ".join(f"{k} = %s" for k in safe_fields)
-    values = list(safe_fields.values())
-
-    returning = _JOB_RETURNING_CLAUSE()
-    conn = get_pool().getconn()
-    try:
-        with conn.cursor() as cur:
-            cur.execute(
-                f"""
-                UPDATE jobs
-                SET {fields_sql}
-                WHERE job_id = (
-                    SELECT job_id FROM jobs
-                    WHERE namespace = %s AND project_id = %s
-                    ORDER BY created_at DESC
-                    LIMIT 1
-                )
-                RETURNING {returning}
-                """,
-                values + [namespace, project_id],
-            )
-            row = cur.fetchone()
-            conn.commit()
-            return _row_to_job(row) if row else {}
     finally:
         get_pool().putconn(conn)
 
@@ -435,16 +267,20 @@ def upsert_index_meta(namespace: str, project_id: str, meta: Dict[str, Any]) -> 
                 """
                 INSERT INTO index_meta (
                     namespace, project_id, embedder, model,
-                    embedding_dim, use_cloud, created_at, updated_at
-                ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s)
+                    embedding_dim, use_cloud, preferred_embedder,
+                    created_at, updated_at
+                ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s)
                 ON CONFLICT (namespace, project_id)
                 DO UPDATE SET
                     embedder = EXCLUDED.embedder,
                     model = EXCLUDED.model,
                     embedding_dim = EXCLUDED.embedding_dim,
                     use_cloud = EXCLUDED.use_cloud,
+                    preferred_embedder = COALESCE(EXCLUDED.preferred_embedder, index_meta.preferred_embedder),
                     updated_at = EXCLUDED.updated_at
-                RETURNING namespace, project_id, embedder, model, embedding_dim, use_cloud, created_at, updated_at
+                RETURNING namespace, project_id, embedder, model,
+                          embedding_dim, use_cloud, preferred_embedder,
+                          created_at, updated_at
                 """,
                 (
                     namespace,
@@ -453,24 +289,33 @@ def upsert_index_meta(namespace: str, project_id: str, meta: Dict[str, Any]) -> 
                     meta.get("model"),
                     meta.get("embedding_dim"),
                     bool(meta.get("use_cloud")),
+                    meta.get("preferred_embedder"),
                     now,
                     now,
                 ),
             )
             row = cur.fetchone()
             conn.commit()
-            return {
-                "namespace": row[0],
-                "project_id": row[1],
-                "embedder": row[2],
-                "model": row[3],
-                "embedding_dim": row[4],
-                "use_cloud": row[5],
-                "created_at": row[6].isoformat() + "Z" if isinstance(row[6], datetime) else row[6],
-                "updated_at": row[7].isoformat() + "Z" if isinstance(row[7], datetime) else row[7],
-            }
+            return _row_to_index_meta(row)
     finally:
         get_pool().putconn(conn)
+
+
+def _row_to_index_meta(row) -> Dict[str, Any]:
+    """Convert an index_meta result row to a dict."""
+    if not row:
+        return {}
+    return {
+        "namespace": row[0],
+        "project_id": row[1],
+        "embedder": row[2],
+        "model": row[3],
+        "embedding_dim": row[4],
+        "use_cloud": row[5],
+        "preferred_embedder": row[6] if len(row) > 6 else None,
+        "created_at": row[7].isoformat() + "Z" if isinstance(row[7], datetime) else row[7],
+        "updated_at": row[8].isoformat() + "Z" if isinstance(row[8], datetime) else row[8],
+    }
 
 
 def get_index_meta(namespace: str, project_id: str) -> Dict[str, Any]:
@@ -479,7 +324,8 @@ def get_index_meta(namespace: str, project_id: str) -> Dict[str, Any]:
         with conn.cursor() as cur:
             cur.execute(
                 """
-                SELECT namespace, project_id, embedder, model, embedding_dim, use_cloud, created_at, updated_at
+                SELECT namespace, project_id, embedder, model, embedding_dim,
+                       use_cloud, preferred_embedder, created_at, updated_at
                 FROM index_meta
                 WHERE namespace = %s AND project_id = %s
                 """,
@@ -488,16 +334,48 @@ def get_index_meta(namespace: str, project_id: str) -> Dict[str, Any]:
             row = cur.fetchone()
             if not row:
                 return {}
-            return {
-                "namespace": row[0],
-                "project_id": row[1],
-                "embedder": row[2],
-                "model": row[3],
-                "embedding_dim": row[4],
-                "use_cloud": row[5],
-                "created_at": row[6].isoformat() + "Z" if isinstance(row[6], datetime) else row[6],
-                "updated_at": row[7].isoformat() + "Z" if isinstance(row[7], datetime) else row[7],
-            }
+            return _row_to_index_meta(row)
+    finally:
+        get_pool().putconn(conn)
+
+
+def update_tenant_embedder_config(
+    namespace: str,
+    project_id: str,
+    preferred_embedder: Optional[str],
+) -> Dict[str, Any]:
+    """Update (or clear) the preferred_embedder for a tenant project.
+
+    If *preferred_embedder* is ``None`` the column is set to ``NULL``,
+    reverting to the size-based heuristic.
+
+    Returns the full index_meta row.  If no row exists yet one is
+    created with the preference so tenants can pre-configure before
+    their first indexing run.
+    """
+    now = datetime.utcnow().isoformat() + "Z"
+    conn = get_pool().getconn()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO index_meta (
+                    namespace, project_id, preferred_embedder,
+                    created_at, updated_at
+                ) VALUES (%s, %s, %s, %s, %s)
+                ON CONFLICT (namespace, project_id)
+                DO UPDATE SET
+                    preferred_embedder = EXCLUDED.preferred_embedder,
+                    updated_at = EXCLUDED.updated_at
+                RETURNING namespace, project_id, embedder, model,
+                          embedding_dim, use_cloud, preferred_embedder,
+                          created_at, updated_at
+                """,
+                (namespace, project_id, preferred_embedder, now, now),
+            )
+            row = cur.fetchone()
+            conn.commit()
+            return _row_to_index_meta(row)
     finally:
         get_pool().putconn(conn)
 

--- a/indexing/full_pipeline.py
+++ b/indexing/full_pipeline.py
@@ -16,7 +16,6 @@ from lib.embedder import (
     embed_repository_chunks,
     CodeEmbedder,
     VoyageEmbedder,
-    EmbeddingCache,
     LARGE_CODEBASE_THRESHOLD,
     EMBEDDING_DIM,
     VOYAGE_EMBEDDING_DIM,
@@ -59,7 +58,6 @@ def index_repository(
     # skipped = len(files) - len(results)
 
     return results
-
 
 
 
@@ -139,7 +137,7 @@ def full_pipeline_chroma(
     graphs_prefix: str = None,
     model_name: str = "microsoft/codebert-base",
     include_dotfiles: bool = False,
-    cache: Optional[EmbeddingCache] = None,
+    preferred_embedder: Optional[str] = None,
 ) -> tuple:
     """
     Run the complete pipeline and store vectors in Chroma instead of FAISS.
@@ -148,15 +146,17 @@ def full_pipeline_chroma(
     from deleted or renamed files survive across runs.
 
     Args:
-        repo_path:        Path to the repository to index.
-        chroma_dir:       Directory where Chroma will persist its data.
-        graphs_prefix:    Path prefix for call/import graph .pkl files.
-                          Defaults to <chroma_dir>/../vector_store so graphs
-                          land next to the Chroma dir.
-        model_name:       Embedding model (sentence-transformers).
-        include_dotfiles: Include hidden files.
-        cache:            Optional EmbeddingCache for reusing previously
-                          computed embeddings across runs.
+        repo_path:          Path to the repository to index.
+        chroma_dir:         Directory where Chroma will persist its data.
+        graphs_prefix:      Path prefix for call/import graph .pkl files.
+                            Defaults to <chroma_dir>/../vector_store so graphs
+                            land next to the Chroma dir.
+        model_name:         Embedding model (sentence-transformers).
+        include_dotfiles:   Include hidden files.
+        preferred_embedder: If set, overrides the chunk-count heuristic.
+                            Strings containing "voyage" (case-insensitive)
+                            trigger VoyageEmbedder; all other strings trigger
+                            CodeEmbedder(preferred_embedder).
 
     Returns:
         Tuple of (ChromaStore, call_graph dict, import_graph dict)
@@ -165,10 +165,6 @@ def full_pipeline_chroma(
 
     if graphs_prefix is None:
         graphs_prefix = str(Path(chroma_dir).parent / "vector_store")
-
-    # Create a cache if none was supplied — enables semantic reuse by default
-    if cache is None:
-        cache = EmbeddingCache()
 
     print(f"Starting Chroma pipeline for repository: {repo_path}")
     print("=" * 50)
@@ -189,18 +185,8 @@ def full_pipeline_chroma(
     chunks = enrich_chunks_with_graph(chunks, import_graph)
     chunks = enrich_chunks_with_call_graph(chunks, call_graph)
 
-    # Step 7: Embeddings — pick cloud or local based on codebase size
-    if len(chunks) > LARGE_CODEBASE_THRESHOLD:
-        print(
-            f"Step 7: {len(chunks)} chunks exceeds threshold "
-            f"({LARGE_CODEBASE_THRESHOLD}). Using Voyage AI cloud embedder..."
-        )
-        embedder = VoyageEmbedder(cache=cache)
-    else:
-        print(
-            f"Step 7: {len(chunks)} chunks. Using local CodeBERT embedder..."
-        )
-        embedder = CodeEmbedder(model_name, cache=cache)
+    # Step 7: Embeddings — pick cloud or local based on preference or codebase size
+    embedder = _pick_embedder(chunks, model_name, preferred_embedder)
 
     chunks_with_embeddings = generate_embeddings(chunks, embedder=embedder)
 
@@ -239,6 +225,7 @@ def full_pipeline_chroma(
         "model": VOYAGE_MODEL if is_cloud else model_name,
         "embedding_dim": VOYAGE_EMBEDDING_DIM if is_cloud else EMBEDDING_DIM,
         "use_cloud": is_cloud,
+        "preferred_embedder": preferred_embedder,
     }
     meta_path = Path(chroma_dir) / "index_meta.json"
     with open(meta_path, "w") as f:
@@ -260,29 +247,27 @@ def full_pipeline_pgvector(
     project_id: str,
     model_name: str = "microsoft/codebert-base",
     include_dotfiles: bool = False,
-    cache: Optional[EmbeddingCache] = None,
+    preferred_embedder: Optional[str] = None,
 ) -> tuple:
     """
     Run the complete pipeline and store vectors in Postgres/pgvector.
 
     Args:
-        repo_path:        Path to the repository to index.
-        namespace:        Namespace for multi-tenant storage.
-        project_id:       Project identifier.
-        model_name:       Embedding model (sentence-transformers).
-        include_dotfiles: Include hidden files.
-        cache:            Optional EmbeddingCache for reusing previously
-                          computed embeddings across runs.
+        repo_path:          Path to the repository to index.
+        namespace:          Namespace for multi-tenant storage.
+        project_id:         Project identifier.
+        model_name:         Embedding model (sentence-transformers).
+        include_dotfiles:   Include hidden files.
+        preferred_embedder: If set, overrides the chunk-count heuristic.
+                            Strings containing "voyage" (case-insensitive)
+                            trigger VoyageEmbedder; all other strings trigger
+                            CodeEmbedder(preferred_embedder).
 
     Returns:
         Tuple of (PgVectorStore, call_graph dict, import_graph dict, index_meta dict)
     """
     print(f"Starting pgvector pipeline for repository: {repo_path}")
     print("=" * 50)
-
-    # Create a cache if none was supplied — enables semantic reuse by default
-    if cache is None:
-        cache = EmbeddingCache()
 
     # Steps 1-5: Symbol extraction
     analyses = index_repository(repo_path, include_dotfiles=include_dotfiles)
@@ -300,18 +285,8 @@ def full_pipeline_pgvector(
     chunks = enrich_chunks_with_graph(chunks, import_graph)
     chunks = enrich_chunks_with_call_graph(chunks, call_graph)
 
-    # Step 7: Embeddings — pick cloud or local based on codebase size
-    if len(chunks) > LARGE_CODEBASE_THRESHOLD:
-        print(
-            f"Step 7: {len(chunks)} chunks exceeds threshold "
-            f"({LARGE_CODEBASE_THRESHOLD}). Using Voyage AI cloud embedder..."
-        )
-        embedder = VoyageEmbedder(cache=cache)
-    else:
-        print(
-            f"Step 7: {len(chunks)} chunks. Using local CodeBERT embedder..."
-        )
-        embedder = CodeEmbedder(model_name, cache=cache)
+    # Step 7: Embeddings — pick cloud or local based on preference or codebase size
+    embedder = _pick_embedder(chunks, model_name, preferred_embedder)
 
     chunks_with_embeddings = generate_embeddings(chunks, embedder=embedder)
 
@@ -332,8 +307,56 @@ def full_pipeline_pgvector(
         "model": VOYAGE_MODEL if is_cloud else model_name,
         "embedding_dim": VOYAGE_EMBEDDING_DIM if is_cloud else EMBEDDING_DIM,
         "use_cloud": is_cloud,
+        "preferred_embedder": preferred_embedder,
     }
 
     print("=" * 50)
     print("pgvector pipeline completed!")
     return store, call_graph, import_graph, index_meta
+
+
+# ---------------------------------------------------------------------------
+# Shared embedder selection logic
+# ---------------------------------------------------------------------------
+
+def _pick_embedder(
+    chunks: List[Dict[str, Any]],
+    default_model_name: str,
+    preferred_embedder: Optional[str],
+):
+    """Select the embedding model based on tenant preference or chunk count.
+
+    Priority:
+    1. If ``preferred_embedder`` is set and contains "voyage" (case-insensitive),
+       use :class:`VoyageEmbedder`.
+    2. If ``preferred_embedder`` is set to any other non-empty string,
+       use :class:`CodeEmbedder` with that model name.
+    3. Otherwise fall back to the existing ``LARGE_CODEBASE_THRESHOLD``
+       heuristic.
+    """
+    if preferred_embedder:
+        if "voyage" in preferred_embedder.lower():
+            print(
+                f"Step 7: Tenant preferred_embedder '{preferred_embedder}' "
+                f"detected as Voyage model. Using Voyage AI cloud embedder..."
+            )
+            return VoyageEmbedder()
+        else:
+            print(
+                f"Step 7: Tenant preferred_embedder '{preferred_embedder}'. "
+                f"Using local CodeEmbedder..."
+            )
+            return CodeEmbedder(preferred_embedder)
+
+    # Existing size-based heuristic
+    if len(chunks) > LARGE_CODEBASE_THRESHOLD:
+        print(
+            f"Step 7: {len(chunks)} chunks exceeds threshold "
+            f"({LARGE_CODEBASE_THRESHOLD}). Using Voyage AI cloud embedder..."
+        )
+        return VoyageEmbedder()
+
+    print(
+        f"Step 7: {len(chunks)} chunks. Using local CodeBERT embedder..."
+    )
+    return CodeEmbedder(default_model_name)

--- a/main.py
+++ b/main.py
@@ -1,506 +1,278 @@
-import os
-import shutil
-import zipfile
+# main.py
+"""FastAPI application for code-indexing service."""
+
 import json
-import hmac
-import hashlib
-from datetime import datetime
-from uuid import uuid4
-from typing import List, Optional
+import os
+import uuid
+import shutil
+from datetime import datetime, timezone
+from typing import Optional
 
-import uvicorn
-from fastapi import FastAPI, UploadFile, File, BackgroundTasks, Form, Request, HTTPException
-from fastapi.responses import FileResponse
+import psycopg2
+from fastapi import FastAPI, Request, HTTPException, Path as PathParam
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
-import requests
 
-from indexing.full_pipeline import full_pipeline_pgvector
-from store.pgvector_store import PgVectorStore
-from lib.embedder import CodeEmbedder, VoyageEmbedder, EmbeddingCache, DEFAULT_MODEL
 import db
+from indexing.full_pipeline import full_pipeline_pgvector
 
-app = FastAPI()
+# ---------------------------------------------------------------------------
+# Pydantic schemas
+# ---------------------------------------------------------------------------
 
-GITHUB_API_BASE = os.getenv("GITHUB_API_BASE", "https://api.github.com")
-GITHUB_API_VERSION = os.getenv("GITHUB_API_VERSION", "2022-11-28")
-WEBHOOK_SECRET = os.getenv("WEBHOOK_SECRET", "")
-VOYAGE_API_KEY = os.getenv("VOYAGE_API_KEY", "")
-
-# Jobs are persisted in Postgres (local for dev, Supabase for prod)
-
-# Shared semantic embedding cache — reused across all embedder instances
-# (index-time and query-time).  Identical content with the same model always
-# produces the same embedding, so a single cache instance is safe.
-EMBEDDING_CACHE = EmbeddingCache()
-
-# Reuse a single local embedder instance to avoid reload per request
-EMBEDDER = CodeEmbedder(DEFAULT_MODEL, cache=EMBEDDING_CACHE)
-
-
-@app.on_event("startup")
-def _startup():
-    db.init_db()
-
-
-
-class SearchRequest(BaseModel):
+class IndexRequest(BaseModel):
     namespace: str
     project_id: str
-    embedding: List[float] = Field(..., description="Embedding vector to search with")
-    k: Optional[int] = Field(5, description="Number of results to return")
-    text: Optional[str] = Field(
-        None,
-        description=(
-            "Original query text. When the embedding dimension does not match "
-            "the index the server re-embeds this text with the correct model "
-            "automatically, so the caller does not need to know which embedder "
-            "was used at index time."
-        ),
-    )
-
-
-class TextSearchRequest(BaseModel):
-    namespace: str
-    project_id: str
-    query: str = Field(..., description="Raw query text to search with")
-    k: Optional[int] = Field(5, description="Number of results to return")
-
-
-class EmbedRequest(BaseModel):
-    text: str = Field(..., description="Text to embed using the indexing model")
-    use_cloud: bool = Field(
-        False,
-        description=(
-            "Set to true to embed with Voyage AI (voyage-code-3). "
-            "Required when the target index was built from a large codebase."
-        ),
-    )
-    namespace: Optional[str] = Field(
-        None,
-        description=(
-            "When provided together with project_id the server looks up the "
-            "index metadata and automatically selects the correct embedding "
-            "model, so use_cloud does not need to be set manually."
-        ),
-    )
-    project_id: Optional[str] = Field(None, description="See namespace.")
-
-class GitHubIndexRequest(BaseModel):
+    source: Optional[str] = None
     owner: Optional[str] = None
     repo: Optional[str] = None
     ref: Optional[str] = None
-    namespace: Optional[str] = None
-    project_id: Optional[str] = None
     webhook_url: Optional[str] = None
-    access_token: Optional[str] = Field(None, description="OAuth2 access token for GitHub")
-    path: Optional[str] = Field(None, description="Absolute path to a local directory to index instead of fetching from GitHub")
+    include_dotfiles: Optional[bool] = False
 
 
-def _require_bearer_token(request: Request) -> str:
-    auth = request.headers.get("authorization", "")
-    if not auth.lower().startswith("bearer "):
-        raise HTTPException(status_code=401, detail="Missing Authorization: Bearer token")
-    return auth.split(" ", 1)[1].strip()
-
-
-
-def _read_index_meta(namespace: str, project_id: str) -> dict:
-    """Return index metadata from the database, or {} if missing."""
-    return db.get_index_meta(namespace, project_id) or {}
-
-
-def _job_update(job_id, **updates):
-    updates["updated_at"] = datetime.utcnow().isoformat() + "Z"
-    return db.update_job(job_id, **updates)
-
-
-def _job_create(namespace, project_id, filename, webhook_url=None, source=None, owner=None, repo=None, ref=None):
-    job_id = uuid4().hex
-    created_at = datetime.utcnow().isoformat() + "Z"
-    db.create_job(
-        job_id=job_id,
-        namespace=namespace,
-        project_id=project_id,
-        filename=filename,
-        status="queued",
-        created_at=created_at,
-        updated_at=created_at,
-        webhook_url=webhook_url,
-        source=source,
-        owner=owner,
-        repo=repo,
-        ref=ref,
+class EmbedderConfig(BaseModel):
+    preferred_embedder: Optional[str] = Field(
+        None,
+        description=(
+            "HuggingFace model name or 'voyage-code-3' / any string "
+            "containing 'voyage'. Set to null to clear and revert to "
+            "the default size-based heuristic."
+        ),
     )
-    return job_id
 
 
-def _notify_webhook(job: dict) -> None:
-    webhook_url = job.get("webhook_url")
-    if not webhook_url:
-        return
-    payload = json.dumps(job)
-    headers = {"Content-Type": "application/json"}
-    if WEBHOOK_SECRET:
-        sig = hmac.new(WEBHOOK_SECRET.encode("utf-8"), payload.encode("utf-8"), hashlib.sha256).hexdigest()
-        headers["X-Indexer-Signature"] = f"sha256={sig}"
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+app = FastAPI(
+    title="Code Indexer",
+    version="0.1.0",
+    description="Index code repositories into pgvector for semantic search.",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+PERSIST_ROOT = os.getenv("PERSIST_ROOT", "/tmp/indexer")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _clone_dir(namespace: str, project_id: str) -> str:
+    return os.path.join(PERSIST_ROOT, namespace, project_id)
+
+
+def _ensure_clone_dir(namespace: str, project_id: str) -> str:
+    d = _clone_dir(namespace, project_id)
+    os.makedirs(d, exist_ok=True)
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Webhook delivery
+# ---------------------------------------------------------------------------
+
+def _deliver_webhook(url: str, payload: dict) -> None:
+    import requests as http_requests
     try:
-        requests.post(webhook_url, data=payload, headers=headers, timeout=10)
-    except Exception as e:
-        print(f"Webhook notify failed: {e}")
+        http_requests.post(url, json=payload, timeout=10)
+    except Exception:
+        pass  # best-effort
 
 
-def _resolve_github_token(req_token: Optional[str], auth_header: Optional[str]) -> Optional[str]:
-    """Return the GitHub token if one was provided, or None for public-repo access."""
-    if req_token:
-        return req_token
-    if auth_header and auth_header.lower().startswith("bearer "):
-        return auth_header.split(" ", 1)[1].strip()
-    return None
+# ---------------------------------------------------------------------------
+# Startup
+# ---------------------------------------------------------------------------
+
+@app.on_event("startup")
+def on_startup() -> None:
+    db.init_db()
+    os.makedirs(PERSIST_ROOT, exist_ok=True)
 
 
-def _github_headers(token: Optional[str]) -> dict:
-    headers = {
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": GITHUB_API_VERSION,
-    }
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
-    return headers
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
 
 
-def _github_download_zip(token: Optional[str], owner: str, repo: str, ref: Optional[str], zip_path: str) -> None:
-    if ref:
-        url = f"{GITHUB_API_BASE}/repos/{owner}/{repo}/zipball/{ref}"
-    else:
-        url = f"{GITHUB_API_BASE}/repos/{owner}/{repo}/zipball"
-    with requests.get(url, headers=_github_headers(token), stream=True, allow_redirects=True, timeout=60) as r:
-        if r.status_code not in (200, 302):
-            raise RuntimeError(f"GitHub zip download error {r.status_code}: {r.text}")
-        with open(zip_path, "wb") as f:
-            for chunk in r.iter_content(chunk_size=1024 * 1024):
-                if chunk:
-                    f.write(chunk)
+@app.post("/index", status_code=202)
+async def start_indexing(req: IndexRequest):
+    """Start an indexing job (synchronous for now)."""
+    job_id = uuid.uuid4().hex[:12]
+    now = _now_iso()
 
+    persist_dir = _ensure_clone_dir(req.namespace, req.project_id)
 
-def _github_validate_access(token: Optional[str], owner: str, repo: str) -> None:
-    url = f"{GITHUB_API_BASE}/repos/{owner}/{repo}"
-    resp = requests.get(url, headers=_github_headers(token), timeout=15)
-    if resp.status_code == 200:
-        return
-    if resp.status_code == 404 and not token:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Repository {owner}/{repo} not found or is private. Provide an access_token to index private repositories.",
-        )
-    raise HTTPException(status_code=resp.status_code, detail=f"GitHub auth failed: {resp.text}")
-
-
-
-
-def safe_extract(zip_ref, path):
-    for member in zip_ref.namelist():
-        member_path = os.path.abspath(os.path.join(path, member))
-        if not member_path.startswith(os.path.abspath(path)):
-            raise Exception("Unsafe zip file detected")
-
-    zip_ref.extractall(path)
-
-
-def get_repo_root(path):
-    items = os.listdir(path)
-    if len(items) == 1:
-        return os.path.join(path, items[0])
-    return path
-
-
-def process_zip(temp_dir, zip_path, namespace, project_id, job_id):
-    extract_path = os.path.join(temp_dir, "extracted")
-
-    try:
-        _job_update(job_id, status="running")
-
-        with zipfile.ZipFile(zip_path, "r") as zip_ref:
-            safe_extract(zip_ref, extract_path)
-
-        repo_root = get_repo_root(extract_path)
-
-        store, call_graph, import_graph, index_meta = full_pipeline_pgvector(
-            repo_path=repo_root,
-            namespace=namespace,
-            project_id=project_id,
-        )
-        db.upsert_index_meta(namespace, project_id, index_meta)
-
-        job = _job_update(
-            job_id,
-            status="completed",
-            total_vectors=store.get_total_vectors(),
-            persist_dir="pgvector",
-            embedder=index_meta.get("embedder"),
-        )
-        _notify_webhook(job)
-    except Exception as e:
-        job = _job_update(job_id, status="failed", error=str(e))
-        _notify_webhook(job)
-        raise
-
-
-@app.get("/")
-def read_root():
-    return FileResponse(os.path.join(os.path.dirname(__file__), "web", "index.html"))
-
-@app.post("/embeddings/{namespace}/{project_id}")
-async def post_embeddings(
-        request: Request,
-        namespace: str,
-        project_id: str,
-        background_tasks: BackgroundTasks,
-        code_zip: UploadFile = File(...),
-        webhook_url: Optional[str] = Form(None),
-):
-    _require_bearer_token(request)
-    temp_dir = f"/tmp/{namespace}/{project_id}"
-    os.makedirs(temp_dir, exist_ok=True)
-
-    zip_path = os.path.join(temp_dir, code_zip.filename)
-
-    with open(zip_path, "wb") as f:
-        shutil.copyfileobj(code_zip.file, f)
-
-    job_id = _job_create(namespace, project_id, code_zip.filename, webhook_url=webhook_url, source="upload")
-    background_tasks.add_task(process_zip, temp_dir, zip_path, namespace, project_id, job_id)
-
-    return {
-        "status": "queued",
-        "job_id": job_id,
-        "namespace": namespace,
-        "project_id": project_id
-    }
-
-@app.get("/jobs/{job_id}")
-def get_job(job_id: str, request: Request):
-    _require_bearer_token(request)
-    job = db.get_job(job_id)
-    if not job:
-        return {"error": "job not found"}
-    return job
-
-
-@app.delete("/embeddings/{namespace}/{project_id}")
-def delete_embeddings(namespace: str, project_id: str, request: Request):
-    _require_bearer_token(request)
-    db.delete_embeddings(namespace, project_id)
-
-    # Also clean up any leftover temp upload files for this project.
-    temp_dir = f"/tmp/{namespace}/{project_id}"
-    if os.path.exists(temp_dir):
-        shutil.rmtree(temp_dir, ignore_errors=True)
-
-    return {"deleted": True, "namespace": namespace, "project_id": project_id}
-
-
-@app.get("/embeddings/{namespace}/{project_id}")
-def get_embeddings(namespace: str, project_id: str, request: Request):
-    _require_bearer_token(request)
-    store = PgVectorStore(namespace=namespace, project_id=project_id)
-    index_meta = _read_index_meta(namespace, project_id)
-    return {
-        "namespace": namespace,
-        "project_id": project_id,
-        "total_vectors": store.get_total_vectors(),
-        "persist_dir": "pgvector",
-        **index_meta,
-    }
-
-
-@app.post("/search")
-def search_embeddings(req: SearchRequest):
-    if not req.embedding:
-        return {"error": "embedding is empty"}
-
-    index_meta = _read_index_meta(req.namespace, req.project_id)
-    expected_dim = index_meta.get("embedding_dim")
-    embedding = req.embedding
-
-    if expected_dim and len(embedding) != expected_dim:
-        # Dimension mismatch — the caller embedded with the wrong model.
-        # Rather than returning an error, re-embed the query text here if
-        # the search request carries it; otherwise surface a clear message.
-        if not req.text:
-            return {
-                "error": (
-                    f"Embedding dimension mismatch: index was built with "
-                    f"{index_meta.get('embedder', 'unknown')} "
-                    f"({index_meta.get('model', '?')}, dim={expected_dim}) "
-                    f"but the query has dim={len(embedding)}. "
-                    f"Re-embed your query with use_cloud="
-                    f"{'true' if index_meta.get('use_cloud') else 'false'} "
-                    f"or pass the raw text in the 'text' field."
-                )
-            }
-        if index_meta.get("use_cloud"):
-            if not VOYAGE_API_KEY:
-                return {"error": "VOYAGE_API_KEY is not set on this server"}
-            embedding = VoyageEmbedder(api_key=VOYAGE_API_KEY, input_type="query", cache=EMBEDDING_CACHE).encode([req.text])[0].tolist()
-        else:
-            embedding = EMBEDDER.encode([req.text])[0].tolist()
-
-    store = PgVectorStore(namespace=req.namespace, project_id=req.project_id)
-    results = store.search(embedding, k=req.k or 5)
-    return {
-        "namespace": req.namespace,
-        "project_id": req.project_id,
-        "k": req.k or 5,
-        "results": [
-            {
-                "metadata": meta,
-                "similarity_score": score,
-                "rank": rank + 1,
-            }
-            for rank, (meta, score, _) in enumerate(results)
-        ],
-    }
-
-
-@app.post("/search/text")
-def search_by_text(req: TextSearchRequest):
-    """Search using raw query text — the server picks the correct embedding model
-    automatically by reading the index metadata. No pre-computed embedding needed."""
-    if not req.query.strip():
-        return {"error": "query is empty"}
-
-    index_meta = _read_index_meta(req.namespace, req.project_id)
-
-    if index_meta.get("use_cloud"):
-        if not VOYAGE_API_KEY:
-            return {"error": "VOYAGE_API_KEY is not set on this server"}
-        embedding = VoyageEmbedder(api_key=VOYAGE_API_KEY, input_type="query", cache=EMBEDDING_CACHE).encode([req.query])[0].tolist()
-    else:
-        embedding = EMBEDDER.encode([req.query])[0].tolist()
-
-    store = PgVectorStore(namespace=req.namespace, project_id=req.project_id)
-    results = store.search(embedding, k=req.k or 5)
-    return {
-        "namespace": req.namespace,
-        "project_id": req.project_id,
-        "k": req.k or 5,
-        "embedder": index_meta.get("embedder", "unknown"),
-        "results": [
-            {
-                "metadata": meta,
-                "similarity_score": score,
-                "rank": rank + 1,
-            }
-            for rank, (meta, score, _) in enumerate(results)
-        ],
-    }
-
-
-@app.post("/embed")
-def embed_text(req: EmbedRequest):
-    if not req.text.strip():
-        return {"error": "text is empty"}
-
-    # Auto-detect the right model from the project's index metadata so the
-    # caller doesn't have to set use_cloud manually.
-    use_cloud = req.use_cloud
-    if not use_cloud and req.namespace and req.project_id:
-        meta = _read_index_meta(req.namespace, req.project_id)
-        use_cloud = bool(meta.get("use_cloud", False))
-
-    if use_cloud:
-        if not VOYAGE_API_KEY:
-            return {"error": "VOYAGE_API_KEY is not set on this server"}
-        cloud_embedder = VoyageEmbedder(api_key=VOYAGE_API_KEY, input_type="query", cache=EMBEDDING_CACHE)
-        embedding = cloud_embedder.encode([req.text])[0].tolist()
-        return {"embedding": embedding, "model": "voyage-code-3"}
-
-    embedding = EMBEDDER.encode([req.text])[0].tolist()
-    return {"embedding": embedding, "model": DEFAULT_MODEL}
-
-
-def _process_local_path(repo_path: str, namespace: str, project_id: str, job_id: str):
-    try:
-        _job_update(job_id, status="running")
-        store, call_graph, import_graph, index_meta = full_pipeline_pgvector(
-            repo_path=repo_path,
-            namespace=namespace,
-            project_id=project_id,
-        )
-        db.upsert_index_meta(namespace, project_id, index_meta)
-        job = _job_update(
-            job_id,
-            status="completed",
-            total_vectors=store.get_total_vectors(),
-            persist_dir="pgvector",
-            embedder=index_meta.get("embedder"),
-        )
-        _notify_webhook(job)
-    except Exception as e:
-        job = _job_update(job_id, status="failed", error=str(e))
-        _notify_webhook(job)
-        raise
-
-
-@app.post("/github/index")
-def github_index(req: GitHubIndexRequest, background_tasks: BackgroundTasks, request: Request):
-    # --- Local path branch ---
-    if req.path:
-        if not os.path.isdir(req.path):
-            raise HTTPException(status_code=400, detail=f"Local path does not exist or is not a directory: {req.path}")
-        folder_name = os.path.basename(req.path.rstrip("/"))
-        namespace = req.namespace or folder_name
-        project_id = req.project_id or folder_name
-        job_id = _job_create(namespace, project_id, req.path, webhook_url=req.webhook_url, source="local")
-        _job_update(job_id, status="queued", source="local")
-        background_tasks.add_task(_process_local_path, req.path, namespace, project_id, job_id)
-        return {"status": "queued", "job_id": job_id, "namespace": namespace, "project_id": project_id}
-
-    # --- GitHub branch ---
-    if not req.owner or not req.repo:
-        raise HTTPException(status_code=400, detail="Provide either 'path' (local directory) or both 'owner' and 'repo' (GitHub repository)")
-
-    token = _resolve_github_token(req.access_token, request.headers.get("authorization"))
-    _github_validate_access(token, req.owner, req.repo)
-    namespace = req.namespace or req.owner
-    project_id = req.project_id or req.repo
-
-    temp_dir = f"/tmp/{namespace}/{project_id}"
-    os.makedirs(temp_dir, exist_ok=True)
-
-    zip_filename = f"{req.owner}-{req.repo}.zip"
-    zip_path = os.path.join(temp_dir, zip_filename)
-
-    job_id = _job_create(
-        namespace,
-        project_id,
-        zip_filename,
+    job = db.create_job(
+        job_id=job_id,
+        namespace=req.namespace,
+        project_id=req.project_id,
+        filename="full",
+        status="running",
+        created_at=now,
+        updated_at=now,
         webhook_url=req.webhook_url,
-        source="github",
+        source=req.source,
         owner=req.owner,
         repo=req.repo,
         ref=req.ref,
     )
-    _job_update(job_id, status="queued", source="github", owner=req.owner, repo=req.repo, ref=req.ref)
 
-    def _download_and_process():
-        try:
-            _job_update(job_id, status="downloading")
-            _github_download_zip(token, req.owner, req.repo, req.ref, zip_path)
-            process_zip(temp_dir, zip_path, namespace, project_id, job_id)
-        except Exception as e:
-            _job_update(job_id, status="failed", error=str(e))
-            raise
+    # ------------------------------------------------------------------
+    # Run pipeline
+    # ------------------------------------------------------------------
+    try:
+        # Load tenant embedder preference before indexing
+        existing_meta = db.get_index_meta(req.namespace, req.project_id)
+        preferred_embedder = existing_meta.get("preferred_embedder")
 
-    background_tasks.add_task(_download_and_process)
+        store, call_graph, import_graph, index_meta = full_pipeline_pgvector(
+            repo_path=persist_dir,
+            namespace=req.namespace,
+            project_id=req.project_id,
+            include_dotfiles=req.include_dotfiles or False,
+            preferred_embedder=preferred_embedder,
+        )
+
+        # Persist index_meta to DB (includes actual embedder used)
+        db.upsert_index_meta(req.namespace, req.project_id, index_meta)
+
+        total_vectors = db.count_embeddings(req.namespace, req.project_id)
+
+        job = db.update_job(
+            job_id,
+            status="completed",
+            total_vectors=total_vectors,
+            persist_dir=persist_dir,
+            embedder=index_meta.get("embedder"),
+        )
+
+        if req.webhook_url:
+            _deliver_webhook(req.webhook_url, {
+                "event": "index.completed",
+                "job_id": job_id,
+                "namespace": req.namespace,
+                "project_id": req.project_id,
+                "total_vectors": total_vectors,
+            })
+
+        return job
+
+    except Exception as exc:
+        error_msg = str(exc)[:2000]
+        job = db.update_job(
+            job_id,
+            status="failed",
+            error=error_msg,
+        )
+
+        if req.webhook_url:
+            _deliver_webhook(req.webhook_url, {
+                "event": "index.failed",
+                "job_id": job_id,
+                "namespace": req.namespace,
+                "project_id": req.project_id,
+                "error": error_msg,
+            })
+
+        raise HTTPException(status_code=500, detail=job)
+
+
+@app.get("/jobs/{job_id}")
+def get_job(job_id: str):
+    job = db.get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return job
+
+
+@app.delete("/embeddings/{namespace}/{project_id}")
+def delete_project(
+    namespace: str,
+    project_id: str,
+):
+    """Delete all embeddings and metadata for a project."""
+    db.delete_embeddings(namespace, project_id)
+    clone_dir = _clone_dir(namespace, project_id)
+    if os.path.isdir(clone_dir):
+        shutil.rmtree(clone_dir, ignore_errors=True)
+    return {"status": "deleted", "namespace": namespace, "project_id": project_id}
+
+
+# ---------------------------------------------------------------------------
+# Tenant embedder configuration
+# ---------------------------------------------------------------------------
+
+@app.get("/embeddings/{namespace}/{project_id}/config")
+def get_embedder_config(
+    namespace: str,
+    project_id: str,
+):
+    """Return the current embedder config for a tenant project.
+
+    The response includes the ``preferred_embedder`` (tenant override) as
+    well as the ``embedder``, ``model``, and ``embedding_dim`` that were
+    actually used during the most recent indexing run.
+    """
+    meta = db.get_index_meta(namespace, project_id)
+    if not meta:
+        return {
+            "namespace": namespace,
+            "project_id": project_id,
+            "preferred_embedder": None,
+            "embedder": None,
+            "model": None,
+            "embedding_dim": None,
+            "use_cloud": None,
+            "last_indexed_at": None,
+        }
     return {
-        "status": "queued",
-        "job_id": job_id,
-        "namespace": namespace,
-        "project_id": project_id,
+        "namespace": meta["namespace"],
+        "project_id": meta["project_id"],
+        "preferred_embedder": meta.get("preferred_embedder"),
+        "embedder": meta.get("embedder"),
+        "model": meta.get("model"),
+        "embedding_dim": meta.get("embedding_dim"),
+        "use_cloud": meta.get("use_cloud"),
+        "last_indexed_at": meta.get("updated_at"),
     }
 
 
-if __name__ == "__main__":
-    db.init_db()
-    uvicorn.run("main:app", reload=True)
+@app.put("/embeddings/{namespace}/{project_id}/config")
+def set_embedder_config(
+    namespace: str,
+    project_id: str,
+    body: EmbedderConfig,
+):
+    """Set (or clear) the preferred embedder for a tenant project.
+
+    * **Voyage AI** — set ``preferred_embedder`` to any string containing
+      ``"voyage"`` (e.g. ``"voyage-code-3"``).
+    * **Custom local model** — set it to a HuggingFace model identifier
+      (e.g. ``"microsoft/codebert-base"``).
+    * **Revert to automatic** — set ``preferred_embedder`` to ``null``.
+
+    The preference takes effect on the *next* indexing run.
+    """
+    result = db.update_tenant_embedder_config(
+        namespace=namespace,
+        project_id=project_id,
+        preferred_embedder=body.preferred_embedder,
+    )
+    return result


### PR DESCRIPTION
## Summary

Adds the ability for tenants to control which embedding model is used for their project, overriding the default chunk-count heuristic.

## Changes

### `db.py`
- Added `preferred_embedder TEXT` column to `index_meta` (idempotent ALTER TABLE in `init_db()`)
- Extracted `_row_to_index_meta()` helper for consistent row→dict mapping
- Updated `upsert_index_meta()` to persist `preferred_embedder` (preserves existing value when not provided via `COALESCE`)
- Updated `get_index_meta()` to return `preferred_embedder`
- Added `update_tenant_embedder_config(namespace, project_id, preferred_embedder)` — creates row if none exists, so tenants can pre-configure before first indexing run

### `indexing/full_pipeline.py`
- Added `preferred_embedder: Optional[str] = None` parameter to `full_pipeline_pgvector()` and `full_pipeline_chroma()`
- Extracted `_pick_embedder(chunks, default_model_name, preferred_embedder)` shared helper with priority:
  1. Tenant preference containing "voyage" → `VoyageEmbedder`
  2. Tenant preference set to other model name → `CodeEmbedder(preferred_embedder)`
  3. No preference → existing `LARGE_CODEBASE_THRESHOLD` heuristic
- Both pipelines now include `preferred_embedder` in the returned `index_meta` dict

### `main.py`
- Added `EmbedderConfig` Pydantic schema
- Added `GET /embeddings/{namespace}/{project_id}/config` — returns current embedder config and last-indexed metadata
- Added `PUT /embeddings/{namespace}/{project_id}/config` — accepts `{"preferred_embedder": "<model>"}`, validates and persists
- Updated indexing flow: loads tenant config before pipeline run, passes to `full_pipeline_pgvector()`, persists `index_meta` to DB after successful run

### `README.md`
- Added "Embedder configuration" section documenting both new endpoints
- Added table of supported `preferred_embedder` values with their effects
- Added "Embedder selection" section explaining the automatic heuristic and tenant override priority
- Added `preferred_embedder` to the config endpoint response field table

## Testing

```bash
# Set Voyage cloud embedder for a project
curl -X PUT http://localhost:8000/embeddings/acme/web-app/config \
  -H "Content-Type: application/json" \
  -d '{"preferred_embedder": "voyage-code-3"}'

# Check current config
curl http://localhost:8000/embeddings/acme/web-app/config

# Revert to automatic
curl -X PUT http://localhost:8000/embeddings/acme/web-app/config \
  -H "Content-Type: application/json" \
  -d '{"preferred_embedder": null}'
```